### PR TITLE
Fix Control Signalling Issue in Automated TLS Benchmarking Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the **development branch**, it may not be in a fully functioning state a
 - [ ] Functioning State*
 - [ ] Up to date documentation
 
+
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 
 ## Main Development Branch Task Tracking


### PR DESCRIPTION
This pull request has been created to address issue #12 

## Summary
There is a bug in the automated TLS benchmarking scripts where the control signalling functionality between the server and client scripts becomes misaligned, causing the test to stall until manually stopped. This issue is more likely to occur when testing across a physical network and is especially prevalent in ARM environments.

To resolve this issue, a review of the methodology for conducting the control signalling between the server and client devices must be reviewed and modified to ensure a sufficient level of robustness and exception handling. 

## Task Details
- Review relevant functions responsible for control signalling in the server and client TLS testing scripts.
- Determine the cause of the signalling mismatch and devise a more robust solution for testing control mechanisms.
- Implement a revised method for control signalling.
- Conduct full testing of the suite’s automated benchmarking to ensure proper functionality in the repository.