### PR TITLE
Add Support for Older Versions of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 


### PR DESCRIPTION
## Summary
The main setup script for the TLS benchmarking suite currently includes the --break-system-packages flag when installing dependencies via pip. However, this flag is only required in newer versions of Python and causes errors when running the script on older versions.

To resolve this issue, the setup script must be updated to detect the Python version in use and apply the --break-system-packages flag conditionally, ensuring compatibility across a wider range of Python versions.

## Task Details
Implement a version check to apply the flag only when necessary
Test the updated script on multiple Python versions to ensure smooth installation
Validate that dependency management remains stable without breaking system packages when using older versions