### PR TITLE
Upgrade OpenSSL Dependency to Security Patch Version 3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The project provides automation for:
 
 - Gathering PQC computational performance data, including **CPU** and **memory usage** metrics using the **Liboqs** library.
 
-- Gathering Networking performance data for the integration of PQC schemes in the **TLS 1.3**  protocol by utilising the **OpenSSL 3.4.0** and **OQS-Provider** libraries.
+- Gathering Networking performance data for the integration of PQC schemes in the **TLS 1.3**  protocol by utilising the **OpenSSL 3.4.1** and **OQS-Provider** libraries.
 
 - Coordinated testing of PQC TLS handshakes using either the loopback interface or a physical network connection between a server and client device.
 
@@ -86,7 +86,7 @@ This version of the repository has been fully tested using the following version
 
 - OQS Provider Version 0.8.0
 
-- OpenSSL Version 3.4.0
+- OpenSSL Version 3.4.1
 
 The repository is currently setup to pull the most up to date versions of the OQS projects and maintain use of the listed OpenSSL version above. This is to ensure the latest available algorithms can be tested and evaluated. Handling has been implemented to accommodate for any changes to the algorithms that are supported by the OQS libraries as newer versions are released.
 
@@ -128,7 +128,7 @@ When executing the setup script, you will be presented with three options:
 
 3. Build the OQS-Provider Library after a previous install of Liboqs
 
-The setup script will also handle the building of [OpenSSL 3.4.0](https://www.openssl.org/source/) within the pqc-eval-tools lib directory as this is required to utilise the OpenSSL provider functionality provided by OQS-Provider. This will be a separate build from the systems default OpenSSL installation and will not replace or interfere with those binaries.
+The setup script will also handle the building of [OpenSSL 3.4.1](https://www.openssl.org/source/) within the pqc-eval-tools lib directory as this is required to utilise the OpenSSL provider functionality provided by OQS-Provider. This will be a separate build from the systems default OpenSSL installation and will not replace or interfere with those binaries.
 
 Additionally, if compiling the OQS-Provider library, the setup script will prompt you to enable the optional KEM encoders feature. This feature is supported by OQS-Provider, but this repository does not currently utilize it. However, developers who wish to take advantage of KEM encoders can enable this option during setup.
 
@@ -184,7 +184,7 @@ The test script can be executed using the following command:
 
 ### OQS-Provider Performance Testing
 
-This script is focused on benchmarking the performance of PQC and Hybrid-PQC algorithms when integrated within the OpenSSL (3.4.0) library via the OQS-Provider. The script firstly can test the computational efficiency of the PQC algorithms when integrated into the OpenSSL library. Alongside, how PQC/Hybrid-PQC algorithms perform when integrated into the TLS protocol by measuring empty TLS handshake performance. Furthermore, metrics for how classic algorithms perform when conducting the TLS handshake which can be used as a baseline to compare the PQC metrics against.  
+This script is focused on benchmarking the performance of PQC and Hybrid-PQC algorithms when integrated within the OpenSSL (3.4.1) library via the OQS-Provider. The script firstly can test the computational efficiency of the PQC algorithms when integrated into the OpenSSL library. Alongside, how PQC/Hybrid-PQC algorithms perform when integrated into the TLS protocol by measuring empty TLS handshake performance. Furthermore, metrics for how classic algorithms perform when conducting the TLS handshake which can be used as a baseline to compare the PQC metrics against.  
 
 The testing tool allows for tests to be conducted on a single machine or using two machines connected via a physical network. It should be noted that when using two physical machines the complexity of setup increases. However, regardless of which scenario, the process requires more additional steps then the Liboqs testing.
 
@@ -254,7 +254,7 @@ python3 get_algorithms.py 1
 ```
 
 ### configure-openssl-cnf.sh <!-- omit from toc --> 
-This script can change the configurations added to the OpenSSL 3.4.0 configuration file by commenting or uncommenting the lines which set what default groups OpenSSL uses. This is needed to allow both the `oqsprovider-generate-keys.sh` and the TLS performance testing scripts to operate correctly. This script is mainly used by the automated scripts, however it can be called manually using the following commands:
+This script can change the configurations added to the OpenSSL 3.4.1 configuration file by commenting or uncommenting the lines which set what default groups OpenSSL uses. This is needed to allow both the `oqsprovider-generate-keys.sh` and the TLS performance testing scripts to operate correctly. This script is mainly used by the automated scripts, however it can be called manually using the following commands:
 
 **configure-openssl-cnf.sh - Comment out Default Group Configurations:**
 ```
@@ -329,7 +329,7 @@ pqc-eval-tools/
 - [OQS-Provider GitHub Page](https://github.com/open-quantum-safe/oqs-provider)
 - [Latest liboqs Release Notes](https://github.com/open-quantum-safe/liboqs/blob/main/RELEASE.md)
 - [Latest OQS-Provider Release Notes](https://github.com/open-quantum-safe/oqs-provider/blob/main/RELEASE.md)
-- [OpenSSL(3.4.0) Documentation](https://docs.openssl.org/3.4/)
+- [OpenSSL(3.4.1) Documentation](https://docs.openssl.org/3.4/)
 - [TLS 1.3 RFC 8446](https://www.rfc-editor.org/rfc/rfc8446)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -5,7 +5,7 @@
 
 # This is a utility script for cleaning the various project files produced from compiling and benchmarking. The script 
 # provides functionality for either uninstalling the OQS-Provider libraries from the system, clearing the old results and generated TLS keys, or both. 
-# When uninstalling, the script will remove the liboqs, OQS-Provider, and OpenSSL 3.4.0 libraries from the system. When clearing the old results and keys,
+# When uninstalling, the script will remove the liboqs, OQS-Provider, and OpenSSL 3.4.1 libraries from the system. When clearing the old results and keys,
 # the script will remove the old test results and generated keys directories from the test-data directory.
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ function setup_base_env() {
     # Declaring global source-code path files
     liboqs_source="$tmp_dir/liboqs-source"
     oqs_provider_source="$tmp_dir/oqs-provider-source"
-    openssl_source="$tmp_dir/openssl-3.4.0"
+    openssl_source="$tmp_dir/openssl-3.4.1"
 
 }
 
@@ -72,7 +72,7 @@ function select_uninstall_mode() {
         echo -e "\nPlease Select one of the following uninstall options"
         echo "1 - Uninstall Liboqs Library Only"
         echo "2 - Uninstall OQS-Provider Library only"
-        echo "3 - Uninstall OpenSSL 3.4.0 Only"
+        echo "3 - Uninstall OpenSSL 3.4.1 Only"
         echo "4 - Uninstall all Libraries"
         echo "5 - Exit Setup"
         read -p "Enter your choice (1-5): " user_opt
@@ -93,9 +93,9 @@ function select_uninstall_mode() {
                 break;;
 
             3)
-                # Uninstall OpenSSL 3.4.0 only
+                # Uninstall OpenSSL 3.4.1 only
                 rm -rf "$openssl_path"
-                echo -e "\nOpenSSL 3.4.0 Uninstalled"
+                echo -e "\nOpenSSL 3.4.1 Uninstalled"
                 break;;
 
             4)

--- a/docs/testing-tools-documentation/tls-performance-testing.md
+++ b/docs/testing-tools-documentation/tls-performance-testing.md
@@ -151,4 +151,4 @@ These scripts together enable the execution of the Full PQC TLS Test, with each 
 - [Latest OQS-Provider Release Notes](https://github.com/open-quantum-safe/oqs-provider/blob/main/RELEASE.md)
 - [OQS Benchmarking Webpage](https://openquantumsafe.org/benchmarking/)
 - [OQS Profiling Project](https://openquantumsafe.org/benchmarking/)
-- [OpenSSL(3.4.0) Documentation](https://docs.openssl.org/3.4/)
+- [OpenSSL(3.4.1) Documentation](https://docs.openssl.org/3.4/)

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -497,7 +497,7 @@ function main() {
     setup_base_env
 
     # Outputting greeting message to the terminal
-    echo -e "PQC OQS-Provider Test Suite (OpenSSL_3.4.0)"
+    echo -e "PQC OQS-Provider Test Suite (OpenSSL_3.4.1)"
 
     # Getting test options and perform tests 
     configure_test_options

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ oqs_provider_path="$libs_dir/oqs-provider"
 # Declaring global source-code path files
 liboqs_source="$tmp_dir/liboqs-source"
 oqs_provider_source="$tmp_dir/oqs-provider-source"
-openssl_source="$tmp_dir/openssl-3.4.0"
+openssl_source="$tmp_dir/openssl-3.4.1"
 
 # Setting Global flag variables
 install_type=0 # 0=Liboqs-only, 1=liboqs+OQS-Provider, 2=OQS-Provider-only
@@ -310,7 +310,7 @@ function handle_oqs_version() {
 
 #-------------------------------------------------------------------------------------------------------------------------------
 function openssl_build() {
-    # Function for building the required version of OpenSSL (3.4.0) for the testing tools
+    # Function for building the required version of OpenSSL (3.4.1) for the testing tools
 
     # Setting thread count for build and Declaring conf file changes array
     threads=$(nproc)
@@ -339,13 +339,13 @@ function openssl_build() {
 
         # Outputting current task to terminal
         echo -e "\n######################################"
-        echo "Downloading and Building OpenSSL-3.4.0"
+        echo "Downloading and Building OpenSSL-3.4.1"
         echo -e "######################################\n"
 
         # Getting required version of openssl and extracting
-        wget -O "$tmp_dir/openssl-3.4.0.tar.gz" https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz
-        tar -xf "$tmp_dir/openssl-3.4.0.tar.gz" -C $tmp_dir
-        rm "$tmp_dir/openssl-3.4.0.tar.gz"
+        wget -O "$tmp_dir/openssl-3.4.1.tar.gz" https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz
+        tar -xf "$tmp_dir/openssl-3.4.1.tar.gz" -C $tmp_dir
+        rm "$tmp_dir/openssl-3.4.1.tar.gz"
 
         # Building required version of OpenSSL in testing-repo directory only
         echo "Building OpenSSL Library"
@@ -368,9 +368,8 @@ function openssl_build() {
 
         # Testing if the new version has correctly installed
         test_output=$("$openssl_path/bin/openssl" version)
-        echo "test_output: $test_output"
 
-        if [[ "$test_output" != "OpenSSL 3.4.0 22 Oct 2024 (Library: OpenSSL 3.4.0 22 Oct 2024)" ]]; then
+        if [[ "$test_output" != "OpenSSL 3.4.1 11 Feb 2025 (Library: OpenSSL 3.4.1 11 Feb 2025)" ]]; then
             echo -e "\n\nERROR: installing required OpenSSL version failed, please verify install process"
             exit 1
         fi
@@ -624,7 +623,7 @@ function main() {
                 get_encoder_build_option
                 dependency_install
 
-                # Building OpenSSL 3.4.0
+                # Building OpenSSL 3.4.1
                 openssl_build
 
                 # Check if liboqs is present and install if not


### PR DESCRIPTION
## Summary
The recent upgrade to OpenSSL 3.4.0 in the repository ([see issue #8](https://github.com/crt26/pqc-evaluation-tools/issues/8)) must now be replaced with version 3.4.1. This version is a security patch release that addresses vulnerabilities present in 3.4.0, including a High-severity CVE.

Further details on the changelog can be found here:
[OpenSSL 3.4.1 Changelog](https://github.com/openssl/openssl/releases/tag/openssl-3.4.1)

To prevent this repository from pulling a version with known security flaws, OpenSSL 3.4.1 must be integrated into the main setup and automated benchmarking scripts.

## Task Details
- Update the OpenSSL dependency to version 3.4.1.
- Verify compatibility with existing functionality.
- Validate that all related components function correctly after the upgrade.