### PR TITLE
Make TLS Benchmarking Ports Configurable and Improve Conflict Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/docs/testing-tools-documentation/tls-performance-testing.md
+++ b/docs/testing-tools-documentation/tls-performance-testing.md
@@ -3,7 +3,7 @@
 ## Contents <!-- omit from toc --> 
 - [Overview](#overview)
 - [Getting Started](#getting-started)
-  - [Ensuring Access to Control Signal Ports in Firewalls](#ensuring-access-to-control-signal-ports-in-firewalls)
+  - [Control Ports and Firewall Setup for Testing](#control-ports-and-firewall-setup-for-testing)
   - [Generating Required Certificates and Private Keys](#generating-required-certificates-and-private-keys)
   - [Testing Tool Execution](#testing-tool-execution)
   - [Testing Options](#testing-options)
@@ -25,22 +25,34 @@ The automated testing tool is currently only supported on the following devices:
 - ARM Linux devices using a 64-bit Debian based Operating System
 
 ## Getting Started
-To begin testing the performance of PQC algorithms when integrated within TLS, there are various steps that must be completed and they differ depending on whether a single machine or two machines are being used. Please fully review this section before conducting the tests to ensure all configurations are correct.
+Before running tests, ensure proper setup based on your testing environment (single vs. dual machine). Review this section to configure everything correctly.
 
 The scripts required for conducting the automated testing are stored in the `scripts/test-scripts` directory which can be found within the project's root directory.
 
-### Ensuring Access to Control Signal Ports in Firewalls
-Before running the various scripts for the automated TLS performance benchmarking, it is first crucial to ensure the testing environment allows communications over the required control signalling ports. These ports are used within the automated Bash scripts to coordinate TLS testing between the server and client machines, including when testing on localhost.
+### Control Ports and Firewall Setup for Testing
+Before running the automated TLS performance benchmarking scripts, ensure that your firewall settings allow communication over the required control signalling ports. These ports enable coordination between the server and client machines, even when testing on localhost
 
-By default, the ports used for control signalling are as follows:
-- **Server TCP Port**: 12345
-- **Client TCP Port**: 12346
+#### Default Ports Used in the Testing Suite
 
-Please ensure the firewall on the testing devices, alongside any firewalls placed between the server and client machines, allow communications on the ports specified above before continuing with the rest of the instructions.
+| **Port Usage**            | **Default Port** |
+|---------------------------|------------------|
+| Server Control TCP Port   | 55000            |
+| Client Control TCP Port   | 55001            |
+| OpenSSL S_Server TCP Port | 4433             |
 
-If needed, these port numbers can be changed directly in the `oqsprovider-test-server.sh` and `oqsprovider-test-client.sh` bash scripts. This can be done by modifying the source and destination port values supplied to the nc commands in the `control_signal` function within these scripts. 
+The server machine must accept incoming traffic on the OpenSSL S_Server port to allow TLS handshake testing. Ensure your firewall settings permit communication on the above ports for both local and remote testing.
 
-> **Note:** Future versions of the repository will facilitate the option to supply custom ports to the testing scripts during setup to reduce the need to edit the script files if the default ports are not suitable.
+#### Using Custom Ports
+
+If the default testing suite TCP ports are **not suitable** for the testing environment, you can specify custom ports when executing the `full-oqs-provider-test.sh` script. This can be done for either the server, the client, or both machines by including the following flags:
+
+```
+--server-control-port=<PORT>    Set the server control port   (1024-65535)
+--client-control-port=<PORT>    Set the client control port   (1024-65535)
+--s-server-port=<PORT>          Set the OpenSSL S_Server port (1024-65535)
+```
+
+When testing between two physical machines, it is essential to specify the same custom ports on both the server and client by including these flags when executing the script on each machine.
 
 ### Generating Required Certificates and Private Keys
 It is necessary to first generate the required server certificate and private key files needed for the TLS performance testing tools before running the automated testing. This can be done by executing the following command from within the `scripts/testing-scripts` directory:

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -96,8 +96,9 @@ function is_port_in_use() {
     # Helper function to determine if a given port is in use.
     # If a process is using the port, it stores the process name in `port_process`.
 
+    # Store the port number and initialise the process name
     local port="$1"
-    port_process=""  # Reset the variable storing the process name
+    port_process=""
 
     # Attempt to check if the port is in use and if so store the process name to check if it is the test suite
     if command -v lsof &>/dev/null; then

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -308,10 +308,10 @@ function pqc_tests() {
                     while true; do
 
                         # Debug line for checking server connection with current sig/kem combination. To use uncomment line and then comment out the s_time line
-                        #"$openssl_path/bin/openssl" s_client -connect $SERVER_IP:4433 -CAfile $cert_file -provider default -provider oqsprovider -provider-path $provider_path -groups "$kem"
+                        #"$openssl_path/bin/openssl" s_client -connect $SERVER_IP:$S_SERVER_PORT -CAfile $cert_file -provider default -provider oqsprovider -provider-path $provider_path -groups "$kem"
 
                         # Running OpenSSL s_time process with current test parameters
-                        "$openssl_path/bin/openssl" s_time -connect $SERVER_IP:4433 -CAfile $cert_file -time $TIME_NUM  -verify 1 \
+                        "$openssl_path/bin/openssl" s_time -connect $SERVER_IP:$S_SERVER_PORT -CAfile $cert_file -time $TIME_NUM  -verify 1 \
                             -provider default -provider oqsprovider -provider-path $provider_path > $handshake_dir/$output_name
                         exit_code=$?
 
@@ -399,7 +399,8 @@ function classic_tests() {
                 while true; do
 
                     # Running OpenSSL s_time process with current test parameters
-                    "$openssl_path/bin/openssl" s_time -connect $SERVER_IP:4433 -CAfile $classic_cert_file -time $TIME_NUM > "$CLASSIC_HANDSHAKE/$output_name"
+                    "$openssl_path/bin/openssl" s_time -connect $SERVER_IP:$S_SERVER_PORT -CAfile $classic_cert_file \
+                        -time $TIME_NUM > "$CLASSIC_HANDSHAKE/$output_name"
                     exit_code=$?
 
                     # Check if test was successful and retrying if not
@@ -457,11 +458,11 @@ function main() {
     clear
 
     # Checking if custom ports have been used and if so, outputting a warning message
-    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ]; then
-        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-        echo "Custom control ports detected, Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT"
-        echo "Please ensure that the server has been passed the same control port values, otherwise tests will fail"
-        echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        echo "Custom TCP ports detected - Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT, S_Server Port: $S_SERVER_PORT"
+        echo "Please ensure that the server has been passed the same custom TCP port values, otherwise tests will fail"
+        echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
     fi
 
     # Performing initial handshake with server

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -165,7 +165,7 @@ function check_control_port() {
     # until the port is open and listening before returning exiting the function, allowing the control_signal function to send the signal.
 
     # Wait until the client is listening on the control port before sending signal
-    until nc -z "$CLIENT_IP" 12346 > /dev/null 2>&1; do
+    until nc -z "$CLIENT_IP" "$CLIENT_CONTROL_PORT" > /dev/null 2>&1; do
         :
     done
 
@@ -183,7 +183,7 @@ function control_signal() {
     local message="$2"
 
     # Kill lingering netcat processes
-    pkill -f "nc -l -p 12345"
+    pkill -f "nc -l -p $SERVER_CONTROL_PORT"
 
     # Determine the type of control signal method to be used
     case "$type" in
@@ -194,7 +194,7 @@ function control_signal() {
             check_control_port
 
             # Send control signal to the client until successful
-            until echo "$message" | nc -n -w 1 "$CLIENT_IP" 12346 > /dev/null 2>&1; do
+            until echo "$message" | nc -n -w 1 "$CLIENT_IP" "$CLIENT_CONTROL_PORT" > /dev/null 2>&1; do
                 exit_status=$?
                 if [ "$exit_status" -ne 0 ]; then
                     :
@@ -210,7 +210,7 @@ function control_signal() {
             while true; do
 
                 # Wait for a connection from the client and capture the request in a variable
-                signal_message=$(nc -l -p 12345)
+                signal_message=$(nc -l -p "$SERVER_CONTROL_PORT")
 
                 # Check if the received control signal message is valid
                 if [[ "$signal_message" == "ready" || "$signal_message" == "skip" || "$signal_message" == "complete" ]]; then
@@ -224,7 +224,7 @@ function control_signal() {
 
             # Wait for the client to send ready signal
             while true; do
-                signal_message=$(nc -l -p 12345)
+                signal_message=$(nc -l -p "$SERVER_CONTROL_PORT")
                 if [[ "$signal_message" == "handshake_ready" ]]; then
                     break
                 fi
@@ -233,8 +233,8 @@ function control_signal() {
             # Check if the control port is open on the client before sending signal
             check_control_port
 
-            # Wait for the server to send ready signal
-            until echo "handshake_ready" | nc -n -w 1 "$CLIENT_IP" 12346 > /dev/null 2>&1; do
+            # Send the handshake ready signal to the client
+            until echo "handshake_ready" | nc -n -w 1 "$CLIENT_IP" "$CLIENT_CONTROL_PORT" > /dev/null 2>&1; do
                 exit_status=$?
                 if [ "$exit_status" -ne 0 ]; then
                     :
@@ -440,7 +440,15 @@ function main() {
     get_algs
     clear
 
-    # Performing initial handshake with client
+    # Checking if custom ports have been used and if so, outputting a warning message
+    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ]; then
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        echo "Custom control port detected, Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT"
+        echo "Please ensure that the client is passed the same control port values"
+        echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    fi
+
+    # Outputting the start message and beginning the initial handshake
     echo -e "Server Script Activated, waiting for connection from client..."
     control_signal "iteration_handshake"
 

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -298,11 +298,11 @@ function pqc_tests() {
 
                 # Starting server process
                 "$openssl_path/bin/openssl" s_server -cert $cert_file -key $key_file -www -tls1_3 -groups $kem \
-                    -provider oqsprovider -provider-path $provider_path -accept 4433 &
+                    -provider oqsprovider -provider-path $provider_path -accept $S_SERVER_PORT &
                 server_pid=$!
 
                 # Check if server has started before sending ready signal
-                until netstat -tuln | grep ':4433' > /dev/null; do
+                until netstat -tuln | grep ":$S_SERVER_PORT" > /dev/null; do
                     :
                 done
 
@@ -375,7 +375,7 @@ function classic_tests {
 
                     # Start ECC test server processes
                     "$openssl_path/bin/openssl" s_server -cert $classic_cert_file -key $classic_key_file -www -tls1_3 \
-                        -named_curve $classic_alg -ciphersuites "$cipher" -accept 4433 &
+                        -named_curve $classic_alg -ciphersuites "$cipher" -accept $S_SERVER_PORT &
 
                     server_pid=$!
 
@@ -386,14 +386,14 @@ function classic_tests {
                     classic_key_file="$classic_cert_dir/$classic_alg-srv.key"
 
                     # Start RSA test server processes
-                    "$openssl_path/bin/openssl" s_server -cert $classic_cert_file -key $classic_key_file -www -tls1_3 -ciphersuites $cipher -accept 4433 &
+                    "$openssl_path/bin/openssl" s_server -cert $classic_cert_file -key $classic_key_file -www -tls1_3 -ciphersuites $cipher -accept $S_SERVER_PORT &
                     server_pid=$!
                     
 
                 fi
 
                 # Check if s_server has started before sending ready signal to client
-                until netstat -tuln | grep ':4433' > /dev/null; do
+                until netstat -tuln | grep ":$S_SERVER_PORT" > /dev/null; do
                     :
                 done
 
@@ -441,11 +441,11 @@ function main() {
     clear
 
     # Checking if custom ports have been used and if so, outputting a warning message
-    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ]; then
-        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-        echo "Custom control port detected, Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT"
-        echo "Please ensure that the client is passed the same control port values"
-        echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        echo "Custom TCP ports detected - Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT, S_Server Port: $S_SERVER_PORT"
+        echo "Please ensure that the client is passed the flags for any custom TCP port values"
+        echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
     fi
 
     # Outputting the start message and beginning the initial handshake


### PR DESCRIPTION
## Summary
The current automated TLS benchmarking scripts use hardcoded TCP ports for control signalling (12345 for the server and 12346 for the client). These ports fall within the range of registered ports and may cause conflicts with other applications. Additionally, users must manually modify the Bash scripts to change these ports, as there is no built-in mechanism to configure them dynamically. There is also no exception handling to check if the ports are already in use on the system before conducting the testing.

To address this issue, a more dynamic solution must be available to the user for configuring the control signal ports and a more reliable set of default ports should be included in the code to avoid any potential conflicts.

## Task Details
Change the default ports used to outside the range of registered TCP ports.
Add functionality to allow users to configure custom control signal ports in the full-oqsprovider-test.sh script.
Add exception handling to accommodate for any conflicts with other services when either using the default ports or the custom ports provided by the user
Update relevant documentation
Perform testing of new functionality to ensure the automated TLS benchmarking still operates correctly