### PR TITLE
Fix False Positives in Port Usage Checks & Relocate Default TLS Benchmarking Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
 - [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/docs/testing-tools-documentation/tls-performance-testing.md
+++ b/docs/testing-tools-documentation/tls-performance-testing.md
@@ -36,8 +36,8 @@ Before running the automated TLS performance benchmarking scripts, ensure that y
 
 | **Port Usage**            | **Default Port** |
 |---------------------------|------------------|
-| Server Control TCP Port   | 55000            |
-| Client Control TCP Port   | 55001            |
+| Server Control TCP Port   | 25000            |
+| Client Control TCP Port   | 25001            |
 | OpenSSL S_Server TCP Port | 4433             |
 
 The server machine must accept incoming traffic on the OpenSSL S_Server port to allow TLS handshake testing. Ensure your firewall settings permit communication on the above ports for both local and remote testing.

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -132,7 +132,7 @@ function is_port_in_use() {
             return 0
         fi
 
-    if command -v lsof &>/dev/null; then
+    elif command -v lsof &>/dev/null; then
 
         # Set the system network tool to lsof
         system_net_tool="lsof"

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -670,15 +670,15 @@ function main() {
     # Main function for controlling OQS-Provider TLS performance testing
 
     # Set default TCP port values
-    server_control_port="55000"
-    client_control_port="55001"
+    server_control_port="25000"
+    client_control_port="25001"
     s_server_port="4433"
 
     # Parse script flags if there are any
     if [[ $# -gt 0 ]]; then
         parse_script_flags "$@"
     fi
-
+    
     # Setting up the base environment for the test suite
     setup_base_env
 

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -458,7 +458,7 @@ function main() {
     clear
 
     # Checking if custom ports have been used and if so, outputting a warning message
-    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
+    if [ "$SERVER_CONTROL_PORT" != "25000" ] || [ "$CLIENT_CONTROL_PORT" != "25001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         echo "Custom TCP ports detected - Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT, S_Server Port: $S_SERVER_PORT"
         echo "Please ensure that the server has been passed the same custom TCP port values, otherwise tests will fail"

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -441,7 +441,7 @@ function main() {
     clear
 
     # Checking if custom ports have been used and if so, outputting a warning message
-    if [ "$SERVER_CONTROL_PORT" != "55000" ] || [ "$CLIENT_CONTROL_PORT" != "55001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
+    if [ "$SERVER_CONTROL_PORT" != "25000" ] || [ "$CLIENT_CONTROL_PORT" != "25001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         echo "Custom TCP ports detected - Server Control Port: $SERVER_CONTROL_PORT, Client Control Port: $CLIENT_CONTROL_PORT, S_Server Port: $S_SERVER_PORT"
         echo "Please ensure that the client is passed the flags for any custom TCP port values"


### PR DESCRIPTION
## Summary
The automated TLS benchmarking script includes a check to determine if any of the TCP ports used by the testing suite are in use by another service before proceeding (first introduced [here](https://github.com/crt26/pqc-evaluation-tools/issues/16)). To allow localhost testing, it attempts to identify whether the process using the port is another instance of the script by checking if it is nc (netcat). However, the method used to capture the process name appears to be incorrect, leading to false positives for port conflicts and preventing the script from running in a single-device setup.

The primary cause of this appears to be when the `ss` command is used to check currently active ports on the system. However, to ensure that none of the three tools used for checking active ports (lsof, ss, netstat) are producing false positives, another review of this approach must be performed.

Additionally, the default ports used by this script (also introduced [here](https://github.com/crt26/pqc-evaluation-tools/issues/16))  fall within the ephemeral port range (49152–65535). This has lead to the scripts to collisions when the operating system randomly assigns the same port for outgoing connections, resulting in netcat errors such as “Address already in use” even though no persistent listener is detected at the time of checking. Consequently, it may be necessary to use default ports below the ephemeral range to remove this breakage in testing.

## Task Details
- Change the default TCP ports used by the script for control signalling to prevent the conflicts with the system. 
- Review how the script captures process names using ss, lsof, and netstat when checking active ports.
- Identify inconsistencies in process name extraction, particularly with ss, that may cause false positives.
- Modify the port-checking logic to ensure accurate detection of processes using the ports.
- Test the updated logic with all three tools across different Linux environments.
- Verify correct behaviour when running the script on both localhost and multiple devices.
- Update documentation if any changes are made to the port detection approach.