### PR TITLE
Fix TLS Speed Benchmark Failure Caused by Excessive Algorithm Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Going forward, this project aims to incorporate other PQC libraries present in t
   - [Standard Setup](#standard-setup)
   - [Safe Setup](#safe-setup)
   - [Ensuring Root Dir Path Marker is Present](#ensuring-root-dir-path-marker-is-present)
+  - [Optional Setup flags](#optional-setup-flags)
 - [Automated Testing Tools](#automated-testing-tools)
   - [Tools Description](#tools-description)
   - [Liboqs Performance Testing](#liboqs-performance-testing)
@@ -163,6 +164,22 @@ To manually regenerate the file, move into the projects root directory and execu
 touch .pqc_eval_dir_marker.tmp
 ```
 
+### Optional Setup flags
+The setup script can accept additional flags when being called to configure certain steps in the setup process.
+
+#### Set MAX_KEM_NUM/MAX_SIG_NUM Value:
+When enabling all the algorithms supported by the `OQS-Provider` library, the automated TLS handshake performance testing will work with no issues but the TLS speed tests using the `OpenSSL speed` tool will fail. This tool is used to gather performance data for the cryptographic operations of digital signature and KEM algorithms when loaded into `OpenSSL`. However, when enabling all the disabled algorithms in `OQS-Provider` library, the tool fails and warns that an excessive number of algorithms has been registered with `OpenSSL`. This is caused by hardcoded variables in the `speed` tool's source code which are capped at a specific value.
+
+This project's setup script has built in mechanisms to determine the number of additional algorithms supplied to `OpenSSl` from `OQS-Provider` and will modify the source code before compiling `OpenSSL` to address this issue by increasing the hardcoded values. However, if for whatever reason this fails or the user wishes the supply a specific value, the setup supports the use of a custom value being used instead.
+
+To manually specify a custom value, use the `--set-speed-new-value` flag when calling the main setup script:
+
+```
+./setup.sh --set-speed-new-value=[integer]
+```
+
+Where `[integer]` is the desired value for the MAX_KEM_NUM and MAX_SIG_NUM variables when modifying the `OpenSSl speed` source code.
+
 ## Automated Testing Tools
 
 ### Tools Description
@@ -242,13 +259,22 @@ The current set of utility scripts includes:
 This is a utility script for cleaning the various project files produced from the compiling and benchmarking operations. The script provides functionality for either uninstalling the OQS and other dependency libraries from the system, clearing the old results and generated TLS keys, or both.
 
 ### get_algorithms.py <!-- omit from toc --> 
-This is a Python utility script which is used to dynamically determine the algorithms which are supported by the version of Liboqs and OQS-Provider libraries installed. These are then outputted accordingly to the `test-data/alg-lists` text files for the different algorithm and test types. The main usage of the script is to be called from the `setup.sh` script where it is passed an argument which dictates which install type is being performed in the setup process. There is also the option to call the `get_algorithms.py` manually to create the algorithm list files if required.
+This is a Python utility script which is used to dynamically determine the algorithms which are supported by the version of Liboqs and OQS-Provider libraries installed. These are then outputted accordingly to the `test-data/alg-lists` text files for the different algorithm and test types. 
+
+The main usage of the script is to be called from the `setup.sh` script where it is passed an argument which dictates which install type is being performed in the setup process. There is also the option to call the `get_algorithms.py` manually to create the algorithm list files if required.
+
+Additionally, the script parses the `ALGORITHMS.md` file from the OQS-Provider source directory to determine the total number of supported algorithms. This function is used internally by setup.sh when enabling all OQS-Provider algorithms. The extracted count is used to modify OpenSSL’s `speed.c` file to accommodate a large number of registered algorithms
 
 Based on the the install type that has been selected in the main setup script, the following integer arguments can be supplied to the utility script:
 
-- 1 - (Liboqs only)
-- 2 - (Liboqs and OQS-Provider)
-- 3 - (OQS-Provider only)
+| Argument | Functionality                                                                                                                 |
+|----------|-------------------------------------------------------------------------------------------------------------------------------|
+| `1`      | Extracts algorithms for **Liboqs only**.                                                                                      |
+| `2`      | Extracts algorithms for **both Liboqs and OQS-Provider**.                                                                     |
+| `3`      | Extracts algorithms for **OQS-Provider only**.                                                                                |
+| `4`      | Parses `ALGORITHMS.md` from **OQS-Provider** to determine the total number of supported algorithms (used only by `setup.sh`). |
+
+While running option `4` manually will work, it is not necessary. This function is used exclusively by the setup.sh script to modify OpenSSL’s speed.c when all OQS-Provider algorithms are enabled. Unlike the other arguments, it does not modify or create any files in the repository as it only returns the algorithm count for use during setup.
 
 
 Example usage when running manually:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
 - [ ] Functioning State*
-- [x] Up to date documentation
+- [ ] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/scripts/test-scripts/oqsprovider-test-speed.sh
+++ b/scripts/test-scripts/oqsprovider-test-speed.sh
@@ -138,12 +138,16 @@ function main() {
         classic_output_filename="$CLASSIC_SPEED/tls-speed-classic-$run_num.txt"
 
         # PQC sig and kem algs speed tests
-        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path -provider oqsprovider  $kem_algs_string > $kem_output_filename
-        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path -provider oqsprovider $sig_algs_string > $sig_output_filename
+        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path \
+            -provider oqsprovider  $kem_algs_string > $kem_output_filename
+        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path \
+            -provider oqsprovider $sig_algs_string > $sig_output_filename
 
         # PQC-Hybrid sig and kem algs speed tests
-        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path -provider oqsprovider  $hybrid_kem_algs_string > $hybrid_kem_output_filename
-        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path -provider oqsprovider $hybrid_sig_algs_string > $hybrid_sig_output_filename
+        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path \
+            -provider oqsprovider  $hybrid_kem_algs_string > $hybrid_kem_output_filename
+        "$open_ssl_path/bin/openssl" speed -seconds $TIME_NUM -provider-path $provider_path \
+            -provider oqsprovider $hybrid_sig_algs_string > $hybrid_sig_output_filename
 
     done
 

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -299,7 +299,7 @@ def parse_oqs_provider_algorithms_md():
         sys.exit(1)
 
     except Exception as e:
-        print(f"[ERROR] - Failed to parse processing file structure: {e}")
+        print(f"Failed to parse processing file structure: {e}")
         sys.exit(1)
 
     # Print out the number of algorithms supported by the OQS-Provider library and exit successfully

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -11,6 +11,7 @@ The accepted arguments are:
     - 1 (Liboqs only)
     - 2 (Liboqs and OQS-Provider)
     - 3 (OQS-Provider only)
+    - 4 (OQS-Provider ALGORITHMS.md parsing)
 
 """
 
@@ -26,6 +27,7 @@ root_dir = ""
 liboqs_build_dir = ""
 openssl_path = ""
 openssl_lib_dir = ""
+oqs_provider_src_dir = ""
 
 #-----------------------------------------------------------------------------------------------------------
 def setup_base_env():
@@ -33,7 +35,7 @@ def setup_base_env():
         and the global library paths for the test suite. The function establishes the root path by determining the path of the script and 
         using this, determines the root directory of the project """
 
-    global root_dir, liboqs_build_dir, openssl_path, openssl_lib_dir
+    global root_dir, liboqs_build_dir, openssl_path, openssl_lib_dir, oqs_provider_src_dir
 
     # Get the script dir location, set current directory, and set the marker filename
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -74,6 +76,9 @@ def setup_base_env():
     old_ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
     new_ld_library_path = f"{openssl_lib_dir}:{old_ld_library_path}"
     os.environ['LD_LIBRARY_PATH'] = new_ld_library_path
+
+    # Set the path to the ALGORITHMS.md file
+    oqs_provider_src_dir = os.path.join(root_dir, "tmp", "oqs-provider-source")
 
     # Ensure that there are no previous list files present (mainly for if this script is ran manually, setup.sh will handle this)
     alg_list_dir = os.path.join(root_dir, "test-data", "alg-lists")
@@ -237,6 +242,69 @@ def set_tls_classic_algs():
     # Write out the classic algorithms to the list files
     write_to_file(classic_kems, kem_list_file)
     write_to_file(classic_sigs, sig_list_file)
+
+#-----------------------------------------------------------------------------------------------------------
+def parse_oqs_provider_algorithms_md():
+    """ Function for parsing the ALGORITHMS.md file of the OQS-Provider library to extract the total number of algorithms supported
+        This is only called when all algorithms are selected to be enabled by the main setup.sh script, as the OpenSSL speed.c source
+        file needs to be altered so that a larger number of algorithms can be supported. This function will return the total number of algorithms
+        supported by the OQS-Provider library and if parsing fails returns -1 to indicate that the hardcoded high value should be set in the speed.c file """
+
+    # Set the filepaths for the ALGORITHMS.md file and declare main_algs list
+    algs_md_filepath = os.path.join(oqs_provider_src_dir, "ALGORITHMS.md")
+    main_algs = []
+
+    # Set the in_table to its default value
+    in_table = False
+
+    # Try to open the ALGORITHMS.md file and extract the algorithms from the table
+    try:
+
+        # Ensure that the file is present
+        if not os.path.isfile(algs_md_filepath):
+            raise FileNotFoundError()
+                
+        # Open the ALGORITHMS.md file and extract the number of algorithms supported
+        with open (algs_md_filepath, "r", encoding='utf-8') as file:
+            for line in file:
+
+                # Determine if the script is currently in the table of algorithms
+                if "<!--- OQS_TEMPLATE_FRAGMENT_IDS_START -->" in line:
+                    in_table = True
+                    continue
+                
+                elif "<!--- OQS_TEMPLATE_FRAGMENT_IDS_END -->" in line:
+                    break
+                
+                # If in the table extract the algorithm names
+                if in_table:
+
+                    # Only extract the algorithms if not in the first lines of the table
+                    if "Algorithm" in line or "--" in line:
+                        continue
+
+                    else:
+
+                        # Extract the algorithm name from the row and store it in the main_algs list
+                        row = line.split("|")
+                        del row[0]
+                        main_algs.append(row[0].strip())
+
+        # Check that the table was found and the algorithm names were extracted
+        if not main_algs:
+            raise Exception("No algorithms found in the table")
+
+    except FileNotFoundError:
+        print(f"File not found: {algs_md_filepath}")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"[ERROR] - Failed to parse processing file structure: {e}")
+        sys.exit(1)
+
+    # Print out the number of algorithms supported by the OQS-Provider library and exit successfully
+    print(f"Total number of Algorithms: {len(main_algs)}")
+    sys.exit(0)
     
 #-----------------------------------------------------------------------------------------------------------
 def main():
@@ -261,6 +329,9 @@ def main():
         elif sys.argv[1] == "3":
             get_tls_pqc_algs()
             set_tls_classic_algs()
+
+        elif sys.argv[1] == "4":
+            parse_oqs_provider_algorithms_md()
 
         else:
             print(f"\nInvalid argument has been passed to this utility script, please check the code of the setup.sh script, or if you are running this script manually, ensure you are passing the correct argument")

--- a/setup.sh
+++ b/setup.sh
@@ -521,8 +521,6 @@ function modify_openssl_src() {
     sed -i "s/#define MAX_SIG_NUM [0-9]\+/#define MAX_SIG_NUM $new_value/g" "$speed_c_filepath"
     sed -i "s/#define MAX_KEM_NUM [0-9]\+/#define MAX_KEM_NUM $new_value/g" "$speed_c_filepath"
 
-    get_user_yes_no "Would you like to continue with the setup process?"
-
     # Ensure that the MAX_KEM_NUM/MAX_SIG_NUM values were successfully modified before continuing
     if ! grep -q "#define MAX_SIG_NUM $new_value" "$speed_c_filepath" || ! grep -q "#define MAX_KEM_NUM $new_value" "$speed_c_filepath"; then
         echo -e "\n[ERROR] - Modifying the MAX_KEM_NUM/MAX_SIG_NUM values in the speed.c file failed, please verify the setup and run a clean install"


### PR DESCRIPTION
## Summary
Functionality was introduced in the `setup.sh script` (see issue [here](https://github.com/crt26/pqc-evaluation-tools/issues/21)) for dynamically enabling the algorithms disabled by default by the `OQS-Provider` library. However, a bug has now been identified when running the `oqsprovider-test-speed.sh` script after completing the TLS handshake performance tests. The speed tests fail due to an excessive number of algorithms being loaded, leading to the following error message:

```
##########################
Performing TLS Speed Tests
##########################

Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
Too many signatures registered. Change MAX_SIG_NUM.
```

To address this bug, a review of the `oqsprovider-test-speed.sh` and how the algorithm groups are supplied to it for testing to determine the cause of the issue and resolve it. Based on the error message, additional flags may also need to be supplied to the build commands for the `OpenSSL` or `oqs-provider` library. 

## Task Details
- Review the `oqsprovider-test-speed.sh` script to analyse how algorithm groups are supplied for testing.
- Identify the cause of excessive algorithm loading and its impact on speed tests.
- Determine if any build flags or configurations for OpenSSL or OQS-Provider need adjustment.
- Test potential fixes and validate that speed tests run successfully.
- Perform full testing of the automated TLS benchmarking scripts to ensure proper functionality 
