### PR TITLE
Add Configurable Control Signal Sleep Time to Automated TLS Testing Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/docs/testing-tools-documentation/tls-performance-testing.md
+++ b/docs/testing-tools-documentation/tls-performance-testing.md
@@ -9,6 +9,9 @@
   - [Testing Options](#testing-options)
   - [Single Machine Testing](#single-machine-testing)
   - [Separate Server and Client Machine Testing](#separate-server-and-client-machine-testing)
+- [Testing Customisation](#testing-customisation)
+  - [Customising TCP Ports](#customising-tcp-ports)
+  - [Adjusting Control Signalling](#adjusting-control-signalling)
 - [Outputted Results](#outputted-results)
 - [Included Testing Scripts](#included-testing-scripts)
 - [Useful Documentation](#useful-documentation)
@@ -42,17 +45,7 @@ Before running the automated TLS performance benchmarking scripts, ensure that y
 
 The server machine must accept incoming traffic on the OpenSSL S_Server port to allow TLS handshake testing. Ensure your firewall settings permit communication on the above ports for both local and remote testing.
 
-#### Using Custom Ports
-
-If the default testing suite TCP ports are **not suitable** for the testing environment, you can specify custom ports when executing the `full-oqs-provider-test.sh` script. This can be done for either the server, the client, or both machines by including the following flags:
-
-```
---server-control-port=<PORT>    Set the server control port   (1024-65535)
---client-control-port=<PORT>    Set the client control port   (1024-65535)
---s-server-port=<PORT>          Set the OpenSSL S_Server port (1024-65535)
-```
-
-When testing between two physical machines, it is essential to specify the same custom ports on both the server and client by including these flags when executing the script on each machine.
+If the default TCP ports do not suite the testing environment in which the scripts are being executed, instructions on using custom ports can be found in the [Test Customisation Section](#testing-customisation).
 
 ### Generating Required Certificates and Private Keys
 It is necessary to first generate the required server certificate and private key files needed for the TLS performance testing tools before running the automated testing. This can be done by executing the following command from within the `scripts/testing-scripts` directory:
@@ -127,6 +120,30 @@ When utilising two separate machines for testing, one machine will be set up as 
 3. Follow the prompts to enter the test parameters.
 
 4. When asked for the other machine's IP, provide the IP address of the server machine.
+
+## Testing Customisation
+The automated PQC TLS benchmarking tool allows users to customise certain parameters used in the testing automation process. This allows greater user configurability in adapting the tool to different network environments and performance requirements. The primary customisable options include TCP ports and control signalling behaviour.
+
+### Customising TCP Ports
+If the default testing suite TCP ports are **not suitable** for the testing environment, you can specify custom ports when executing the `full-oqs-provider-test.sh` script. This can be done for either the server, the client, or both machines by including the following flags:
+
+```
+--server-control-port=<PORT>    Set the server control port   (1024-65535)
+--client-control-port=<PORT>    Set the client control port   (1024-65535)
+--s-server-port=<PORT>          Set the OpenSSL S_Server port (1024-65535)
+```
+
+When testing between two physical machines, it is essential to specify the same custom ports on both the server and client by including these flags when executing the script on each machine.
+
+### Adjusting Control Signalling
+If the default control signalling behaviour is **not suitable** for the testing environment, you can customise the control sleep time or disable it entirely when executing the `full-oqs-provider-test.sh` script. By default, a sleep time of 0.25 seconds is used when handshakes occur between testing machines. You can adjust this by including the following flags:
+
+```
+--control-sleep-time=<TIME>     Set the control sleep time in seconds (integer or float)
+--disable-control-sleep         Disable the control signal sleep time
+```
+
+Note that the `--control-sleep-time` flag cannot be used together with the `--disable-control-sleep` flag.
 
 ## Outputted Results
 The results from the Full PQC TLS Test will be stored in the `test-data/up-results/ops-provider/machine-x` directory, which can be found within the code's root directory. The results include handshake and speed test results for both PQC and classic ciphersuites. This directory is used to store all of the unparsed results from the automated testing tools.

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -10,6 +10,38 @@
 # If executing both server and client on the same machine, this is not needed as the client can access the keys directly.
 
 #-------------------------------------------------------------------------------------------------------------------------------
+function get_user_yes_no() {
+    # Helper function for getting a yes or no response from the user for a given question regarding the setup process
+
+    local user_prompt="$1"
+
+    # Get the user input for the yes or no question
+    while true; do
+        read -p "$user_prompt (y/n): " user_input
+
+        case $user_input in
+
+            [Yy]* )
+                user_y_n_response=1
+                return 0
+                ;;
+
+            [Nn]* )
+                user_y_n_response=0
+                return 1
+                ;;
+
+            * )
+                echo -e "Please answer y or n\n"
+                ;;
+
+        esac
+
+    done
+
+}
+
+#-------------------------------------------------------------------------------------------------------------------------------
 function is_valid_port() {
     # Helper function called by parse_script_flags to check if the custom port passed to the script when called is a valid TCP port number
 
@@ -38,7 +70,7 @@ function parse_script_flags {
 
                 # Check if the port number is valid
                 if ! is_valid_port "$server_control_port"; then
-                    echo -e "[ERROR] - Invalid server control port number: $server_control_port"
+                    echo "[ERROR] - Invalid server control port number: $server_control_port"
                     exit 1
                 fi
                 shift
@@ -51,7 +83,7 @@ function parse_script_flags {
 
                 # Check if the port number is valid
                 if ! is_valid_port "$client_control_port"; then
-                    echo -e "[ERROR] - Invalid client control port number: $client_control_port"
+                    echo "[ERROR] - Invalid client control port number: $client_control_port"
                     exit 1
                 fi
                 shift
@@ -64,7 +96,7 @@ function parse_script_flags {
 
                 # Check if the port number is valid
                 if ! is_valid_port "$s_server_port"; then
-                    echo -e "[ERROR] - Invalid s_server port number: $s_server_port"
+                    echo "[ERROR] - Invalid s_server port number: $s_server_port"
                     exit 1
                 fi
                 shift
@@ -72,60 +104,46 @@ function parse_script_flags {
 
             --control-sleep-time=*)
 
+                # Check to see if the disable control sleep flag has been set
+                if [ "$disable_control_sleep" == "True" ]; then
+                    echo "[ERROR] - Cannot use the --control-sleep-time flag when the --disable-control-sleep flag has been set"
+                    exit 1
+                fi
+
                 # Store the custom control sleep time and set the custom control time flag
                 control_sleep_time="${1#*=}"
                 custom_control_time_flag="True"
 
-                # Check if the sleep timer is valid interger or float
+                # Check if the sleep timer is valid integer or float
                 if [[ ! $control_sleep_time =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-                    echo -e "\n[ERROR] - Invalid control sleep time: $control_sleep_time"
+                    echo "[ERROR] - Invalid control sleep time: $control_sleep_time"
                     exit 1
-                fi
-
-                # Check if the sleep timer is below the lowest tested value
-                if (( $(echo "$control_sleep_time < 0.25" | bc -l) )); then
-
-                    # Output warning to the user
-                    echo -e "\n[WARNING] - Control sleep time is below the lowest tested value of 0.25 seconds"
-                    echo "In most instances this should be fine, but some environments have shown testing to fail using lower values"
-
-
-                    # Ask the user if they wish to continue with the lower value
-                    while true; do
-
-                        read -p "Do you wish to continue with the sleep timer set to $control_sleep_time seconds? [y/n] - " user_response
-
-                        case $user_response in
-
-                            [Yy]* )
-                                break
-                                ;;
-
-                            [Nn]* )
-                                echo -e "\nExiting script..."
-                                exit 1
-                                ;;
-
-                            * )
-                                echo -e "Please enter a valid response [y/n]\n"
-                                ;;
-
-                        esac
-
-                    done
-
-
                 fi
                 shift
                 ;;
 
+            --disable-control-sleep)
+
+                # Check if the custom sleep time flag has been
+                if [ "$custom_control_time_flag" == "True" ]; then
+                    echo "[ERROR] - Cannot use the --disable-control-sleep flag when the --control-sleep-time flag has been set"
+                    exit 1
+                fi
+
+                # Set the disable control sleep flag and shift
+                disable_control_sleep="True"
+                shift
+                ;;
+
+
             *)
                 echo "[ERROR] - Unknown option: $1"
                 echo "Valid options are:"
-                echo "  --server-control-port=<PORT>    Set the server control port             (1024-65535)"
-                echo "  --client-control-port=<PORT>    Set the client control port             (1024-65535)"
-                echo "  --s-server-port=<PORT>          Set the OpenSSL S_Server port           (1024-65535)"
-                echo "  --control-sleep-time=<TIME>     Set the control sleep time in seconds   (integer or float)"
+                echo "  --server-control-port=<PORT>       Set the server control port             (1024-65535)"
+                echo "  --client-control-port=<PORT>       Set the client control port             (1024-65535)"
+                echo "  --s-server-port=<PORT>             Set the OpenSSL S_Server port           (1024-65535)"
+                echo "  --control-sleep-time=<TIME>        Set the control sleep time in seconds   (integer or float)"
+                echo "  --disable-control-sleep            Disable the control signal sleep time"
                 exit 1
                 ;;
 
@@ -137,6 +155,43 @@ function parse_script_flags {
     if [ "$server_control_port" == "$client_control_port" ] || [ "$server_control_port" == "$s_server_port" ] || [ "$client_control_port" == "$s_server_port" ]; then
         echo -e "[ERROR] - Custom TCP ports cannot be the same"
         exit 1
+    fi
+
+    # If the custom control sleep time flag has been set, perform additional checks
+    if [ "$custom_control_time_flag" == "True" ]; then
+
+        # Check if the set sleep time value falls into given special cases
+        if (( $(echo "$control_sleep_time > 0 && $control_sleep_time < 0.25" | bc -l) )); then
+
+            # Output warning to the user
+            echo "[WARNING] - Control sleep time is below the lowest tested value of 0.25 seconds"
+            echo "In most instances this should be fine, but some environments have shown testing to fail using lower values"
+
+            # Ask the user if they wish to continue with the lower value
+            get_user_yes_no "Do you wish to continue with the sleep timer set to $control_sleep_time seconds?"
+
+            # Check the user response
+            if [ $user_y_n_response -eq 0 ]; then
+                echo -e "\nExiting script..."
+                exit 1
+            fi
+
+        elif (( $(echo "$control_sleep_time == 0" | bc -l) )); then
+
+            # Output the situation to the user and get their response
+            echo "[NOTICE] - You have set the control sleep time to 0 seconds"
+            get_user_yes_no "Do you wish to disable the control signal sleep statement?"
+
+            # Check the user response
+            if [ $user_y_n_response -eq 1 ]; then
+                disable_control_sleep="True"
+            else
+                echo -e "\nExiting script..."
+                exit 1
+            fi
+
+        fi
+    
     fi
 
 }
@@ -295,11 +350,16 @@ function setup_base_env() {
     export CLIENT_CONTROL_PORT="$client_control_port"
     export S_SERVER_PORT="$s_server_port"
 
-    # Exporting the control sleep time variable
-    if [ -n "$custom_control_time_flag" ]; then
-        export CONTROL_SLEEP_TIME="$control_sleep_time"
-    else
+    # Determine what control signal parameters to export
+    if [ "$disable_control_sleep" == "False" ] && [ "$custom_control_time_flag" == "False" ]; then
         export CONTROL_SLEEP_TIME="0.25"
+
+    elif [ "$disable_control_sleep" == "False" ] && [ "$custom_control_time_flag" == "True" ]; then
+        export CONTROL_SLEEP_TIME="$control_sleep_time"
+    
+    elif [ "$disable_control_sleep" == "True" ]; then
+        export DISABLE_CONTROL_SLEEP="True"
+
     fi
 
     # Define the flag and arrays used for the port checking
@@ -393,6 +453,11 @@ function clean_environment() {
     unset CLIENT_CONTROL_PORT
     unset S_SERVER_PORT
     unset CONTROL_SLEEP_TIME
+
+    # Clearing DISABLE_CONTROL_SLEEP variable if set
+    if [ -z $DISABLE_CONTROL_SLEEP ]; then
+        unset DISABLE_CONTROL_SLEEP
+    fi
 
     # Clearing result types paths 
     for var in "${result_dir_paths[@]}"; do
@@ -566,7 +631,7 @@ function configure_test_options {
 
     # Outputting option parameter title
 
-    echo -e "\n#########################"
+    echo -e "#########################"
     echo "Configure Test Parameters"
     echo -e "#########################\n"
 
@@ -709,7 +774,7 @@ function run_tests() {
     # Function that will call the relevant benchmarking utility scripts for the TLS handshake and speed tests
    
     # Setting regex variable for checking IP address format entered by user
-    ipv4_regex_check="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
+    ipv4_regex_check="^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$"
 
     # Getting the IP address of the other machine from the user
     while true; do
@@ -723,11 +788,19 @@ function run_tests() {
 
         # Checking if the IP address entered is in the correct format
         if [[ $ip_address =~ $ipv4_regex_check ]]; then
-            echo "Other test machine set to - $ip_address"
-            machine_ip=$ip_address
-            break
+
+            # Ensure that the IP address is not set to 0.0.0.0 or 255.255.255.255 before continuing
+            if [[ "$ip_address" == "0.0.0.0" || "$ip_address" == "255.255.255.255" ]]; then
+                echo "Invalid IP address: $ip_address. Please enter a valid IP address."
+            else
+                echo "Other test machine set to - $ip_address"
+                machine_ip=$ip_address
+                break
+            fi
+
         else
             echo "Invalid IP format, please try again"
+
         fi
     
     done
@@ -739,7 +812,6 @@ function run_tests() {
 
     # Calling key transfer check and clearing output to tidy terminal output
     check_transferred_keys
-    clear
 
     # Running handshake test script based on machine type selected
     if [ $machine_type == "Server" ]; then
@@ -780,6 +852,10 @@ function run_tests() {
 #-------------------------------------------------------------------------------------------------------------------------------
 function main() {
     # Main function for controlling OQS-Provider TLS performance testing
+
+    # Set the default global flag variables
+    custom_control_time_flag="False"
+    disable_control_sleep="False"
 
     # Set default TCP port values
     server_control_port="25000"

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -79,8 +79,8 @@ function setup_base_env() {
     classic_algs=( "RSA_2048" "RSA_3072" "RSA_4096" "prime256v1" "secp384r1" "secp521r1")
     ciphers=("TLS_AES_256_GCM_SHA384" "TLS_CHACHA20_POLY1305_SHA256" "TLS_AES_128_GCM_SHA256")
 
-    # Ensure that a control sleep time env variables has been passed
-    if [ -z "$CONTROL_SLEEP_TIME" ]; then
+    # Ensure that a control sleep time env variables has been passed if not disabled
+    if [ -z "$CONTROL_SLEEP_TIME" ] && [ -z "$DISABLE_CONTROL_SLEEP" ]; then
         echo "[ERROR] - Control sleep time env variable not set, this indicates a wider issue with the full-oqs-provider-test.sh script"
         exit 1
     fi
@@ -175,8 +175,10 @@ function check_control_port() {
         :
     done
 
-    # Small delay before sending signal to allow target device to open port and listen
-    sleep $CONTROL_SLEEP_TIME
+    # Perform small delay before sending signal to allow target device to open port and listen
+    if [ -v $DISABLE_CONTROL_SLEEP ]; then
+        sleep $CONTROL_SLEEP_TIME
+    fi
 
 }
 

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -79,6 +79,12 @@ function setup_base_env() {
     classic_algs=( "RSA_2048" "RSA_3072" "RSA_4096" "prime256v1" "secp384r1" "secp521r1")
     ciphers=("TLS_AES_256_GCM_SHA384" "TLS_CHACHA20_POLY1305_SHA256" "TLS_AES_128_GCM_SHA256")
 
+    # Ensure that a control sleep time env variables has been passed
+    if [ -z "$CONTROL_SLEEP_TIME" ]; then
+        echo "[ERROR] - Control sleep time env variable not set, this indicates a wider issue with the full-oqs-provider-test.sh script"
+        exit 1
+    fi
+
 }
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -170,7 +176,7 @@ function check_control_port() {
     done
 
     # Small delay before sending signal to allow target device to open port and listen
-    sleep 0.25
+    sleep $CONTROL_SLEEP_TIME
 
 }
 
@@ -452,9 +458,6 @@ function main() {
 
     # Setting up the base environment for the test suite
     setup_base_env
-
-    # Import algorithms and clear terminal
-    get_algs
     clear
 
     # Checking if custom ports have been used and if so, outputting a warning message

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -79,8 +79,8 @@ function setup_base_env() {
     classic_algs=("RSA_2048" "RSA_3072" "RSA_4096" "prime256v1" "secp384r1" "secp521r1")
     ciphers=("TLS_AES_256_GCM_SHA384" "TLS_CHACHA20_POLY1305_SHA256" "TLS_AES_128_GCM_SHA256")
 
-    # Ensure that a control sleep time env variables has been passed
-    if [ -z "$CONTROL_SLEEP_TIME" ]; then
+    # Ensure that a control sleep time env variables has been passed if not disabled
+    if [ -z "$CONTROL_SLEEP_TIME" ] && [ -z "$DISABLE_CONTROL_SLEEP" ]; then
         echo "[ERROR] - Control sleep time env variable not set, this indicates a wider issue with the full-oqs-provider-test.sh script"
         exit 1
     fi
@@ -175,8 +175,10 @@ function check_control_port() {
         :
     done
 
-    # Small delay before sending signal to allow target device to open port and listen
-    sleep $CONTROL_SLEEP_TIME
+    # Perform small delay before sending signal to allow target device to open port and listen
+    if [ -v $DISABLE_CONTROL_SLEEP ]; then
+        sleep $CONTROL_SLEEP_TIME
+    fi
 
 }
 

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -79,6 +79,12 @@ function setup_base_env() {
     classic_algs=("RSA_2048" "RSA_3072" "RSA_4096" "prime256v1" "secp384r1" "secp521r1")
     ciphers=("TLS_AES_256_GCM_SHA384" "TLS_CHACHA20_POLY1305_SHA256" "TLS_AES_128_GCM_SHA256")
 
+    # Ensure that a control sleep time env variables has been passed
+    if [ -z "$CONTROL_SLEEP_TIME" ]; then
+        echo "[ERROR] - Control sleep time env variable not set, this indicates a wider issue with the full-oqs-provider-test.sh script"
+        exit 1
+    fi
+
 }
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -170,7 +176,7 @@ function check_control_port() {
     done
 
     # Small delay before sending signal to allow target device to open port and listen
-    sleep 0.25
+    sleep $CONTROL_SLEEP_TIME
 
 }
 
@@ -435,9 +441,6 @@ function main() {
 
     # Setting up the base environment for the test suite
     setup_base_env
-
-    # Import algorithms and clear terminal
-    get_algs
     clear
 
     # Checking if custom ports have been used and if so, outputting a warning message


### PR DESCRIPTION
## Summary
The `full-oqs-provider-test.sh` script currently uses a fixed control signal sleep time during execution, which may not be optimal for all environments and test scenarios. Users should be able to specify a custom sleep duration to improve flexibility and accommodate different system performance characteristics. This will allow adjustments to be made in cases where deadlocks occur with the default sleep time of 0.25 seconds, without requiring manual modifications to the testing scripts.

To address this, the script must be updated to accept a user-defined sleep time as a parameter while maintaining a reasonable default value. This enhancement will enable users to fine-tune the test execution timing based on their specific requirements.

## Task Details
- Modify `full-oqs-provider-test.sh` to accept an optional parameter for control signal sleep time.
- Update the `oqsprovider-test-server.sh` and `oqsprovider-test-client.sh` scripts to use the custom value if defined
- Conduct thorough testing to confirm that both the default and custom sleep values function as expected without causing unintended behaviour.
- Update documentation to reflect the new functionality and provide usage examples.