### PR TITLE
Add support for help Flags in Project Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc --> 
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 <!-- > *Dev branch Notice: Current functioning state works for both x86 and ARM machines. However, on ARM devices, memory profiling for Falcon algorithm variations is non-functioning. Please refer to [bug-report-on-liboqs-repo](https://github.com/open-quantum-safe/liboqs/issues/1761) for more details. Work is underway to resolve this issue but for now the repository has methods in place to account for this. Automated testing and parsing scripts can still be used to gather performance metrics for all other algorithms on ARM systems.  -->
 

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -42,6 +42,22 @@ function get_user_yes_no() {
 }
 
 #-------------------------------------------------------------------------------------------------------------------------------
+function output_help_message() {
+    # Helper function for outputting the help message to the user when called or when incorrect arguments are passed
+
+    # Output the supported options and their usage to the user
+    echo "Usage: full-oqs-provider-test.sh [options]"
+    echo "Options:"
+    echo "  --server-control-port=<PORT>       Set the server control port             (1024-65535)"
+    echo "  --client-control-port=<PORT>       Set the client control port             (1024-65535)"
+    echo "  --s-server-port=<PORT>             Set the OpenSSL S_Server port           (1024-65535)"
+    echo "  --control-sleep-time=<TIME>        Set the control sleep time in seconds   (integer or float)"
+    echo "  --disable-control-sleep            Disable the control signal sleep time"
+    echo "  --help                             Display the help message"
+
+}
+
+#-------------------------------------------------------------------------------------------------------------------------------
 function is_valid_port() {
     # Helper function called by parse_script_flags to check if the custom port passed to the script when called is a valid TCP port number
 
@@ -58,6 +74,12 @@ function is_valid_port() {
 #-------------------------------------------------------------------------------------------------------------------------------
 function parse_script_flags {
     # Function for parsing the flags passed to the script when called
+
+    # Check if the help flag is passed at any position
+    if [[ "$*" =~ --help ]]; then
+        output_help_message
+        exit 0
+    fi
 
     # Check if custom control port flags have been passed to the script
     while [[ $# -gt 0 ]]; do
@@ -138,12 +160,7 @@ function parse_script_flags {
 
             *)
                 echo "[ERROR] - Unknown option: $1"
-                echo "Valid options are:"
-                echo "  --server-control-port=<PORT>       Set the server control port             (1024-65535)"
-                echo "  --client-control-port=<PORT>       Set the client control port             (1024-65535)"
-                echo "  --s-server-port=<PORT>             Set the OpenSSL S_Server port           (1024-65535)"
-                echo "  --control-sleep-time=<TIME>        Set the control sleep time in seconds   (integer or float)"
-                echo "  --disable-control-sleep            Disable the control signal sleep time"
+                output_help_message
                 exit 1
                 ;;
 

--- a/scripts/test-scripts/oqsprovider-generate-keys.sh
+++ b/scripts/test-scripts/oqsprovider-generate-keys.sh
@@ -186,6 +186,7 @@ function hybrid_pqc_keygen() {
             -out "$hybrid_cert_dir/$sig-srv.crt" -CA "$hybrid_cert_dir/$sig-CA.crt" -CAkey "$hybrid_cert_dir/$sig-CA.key" -CAcreateserial -days 365
 
     done
+
 }
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -199,7 +200,10 @@ function main() {
     get_algs
 
     # Modifying the OpenSSL conf file to temporarily remove the default groups configuration
-    "$util_scripts/configure-openssl-cnf.sh" 0
+    if ! "$util_scripts/configure-openssl-cnf.sh" 0; then
+        echo "[ERROR] - Failed to modify OpenSSL configuration."
+        exit 1
+    fi
 
     # Removing old keys if present and creating key directories
     if [ -d "$keys_dir" ]; then
@@ -220,7 +224,10 @@ function main() {
     hybrid_pqc_keygen
 
     # Restoring OpenSSL conf file to have configuration needed for testing scripts
-    "$util_scripts/configure-openssl-cnf.sh" 1
+    if ! "$util_scripts/configure-openssl-cnf.sh" 1; then
+        echo "[ERROR] - Failed to modify OpenSSL configuration."
+        exit 1
+    fi
 
 }
 main

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -123,7 +123,10 @@ function set_test_env() {
         current_group="${current_group:1}"
 
         # Set configurations in openssl.cnf file for PQC testing
-        "$util_scripts/configure-openssl-cnf.sh" $configure_mode
+        if ! "$util_scripts/configure-openssl-cnf.sh" $configure_mode; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+        fi
 
     elif [ "$test_type" -eq 1 ]; then
 
@@ -148,7 +151,10 @@ function set_test_env() {
         current_group="${current_group:1}"
 
         # Set configurations in openssl.cnf file for PQC testing
-        "$util_scripts/configure-openssl-cnf.sh" $configure_mode
+        if ! "$util_scripts/configure-openssl-cnf.sh" $configure_mode; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+        fi
 
     elif [ "$test_type" -eq 2 ]; then
 
@@ -156,7 +162,10 @@ function set_test_env() {
         current_group="ffdhe2048:ffdhe3072:ffdhe4096:prime256v1:secp384r1:secp521r1"
 
         # Set configurations in openssl.cnf file for Classic testing
-        "$util_scripts/configure-openssl-cnf.sh" $configure_mode
+        if ! "$util_scripts/configure-openssl-cnf.sh" $configure_mode; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+        fi
 
     fi
 

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -123,7 +123,10 @@ function set_test_env() {
         current_group="${current_group:1}"
 
         # Set configurations in openssl.cnf file for PQC testing
-        "$util_scripts/configure-openssl-cnf.sh" $configure_mode
+        if ! "$util_scripts/configure-openssl-cnf.sh" $configure_mode; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+        fi
 
     elif [ "$test_type" -eq 1 ]; then
 
@@ -148,7 +151,10 @@ function set_test_env() {
         current_group="${current_group:1}"
 
         # Set configurations in openssl.cnf file for PQC testing
-        "$util_scripts/configure-openssl-cnf.sh" $configure_mode
+        if ! "$util_scripts/configure-openssl-cnf.sh" $configure_mode; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+        fi
 
     elif [ "$test_type" -eq 2 ]; then
 
@@ -156,7 +162,10 @@ function set_test_env() {
         current_group="ffdhe2048:ffdhe3072:ffdhe4096:prime256v1:secp384r1:secp521r1"
 
         # Set configurations in openssl.cnf file for Classic testing
-        "$util_scripts/configure-openssl-cnf.sh" $configure_mode
+        if ! "$util_scripts/configure-openssl-cnf.sh" $configure_mode; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+        fi
 
     fi
 

--- a/scripts/test-scripts/oqsprovider-test-speed.sh
+++ b/scripts/test-scripts/oqsprovider-test-speed.sh
@@ -125,7 +125,10 @@ function main() {
     hybrid_sig_algs_string="${hybrid_sig_algs[@]}"
 
     # Modifying the OpenSSL conf file to temporarily remove the default groups configuration
-    "$util_scripts/configure-openssl-cnf.sh" 0
+    if ! "$util_scripts/configure-openssl-cnf.sh" 0; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+    fi
 
     # Performing TLS speed tests for the various test types
     for run_num in $(seq 1 $NUM_RUN); do
@@ -152,7 +155,10 @@ function main() {
     done
 
     # Restoring OpenSSL conf file to have configuration needed for testing scripts
-    "$util_scripts/configure-openssl-cnf.sh" 1
+    if ! "$util_scripts/configure-openssl-cnf.sh" 1; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration."
+            exit 1
+    fi
 
 }
 main

--- a/scripts/utility-scripts/configure-openssl-cnf.sh
+++ b/scripts/utility-scripts/configure-openssl-cnf.sh
@@ -8,6 +8,78 @@
 # comment out the default groups in the configuration file to allow for the use of the scheme groups included with the OQS-Provider library.
 
 #-------------------------------------------------------------------------------------------------------------------------------
+function output_help_message() {
+    # Helper function for outputting the help message to the user when called or when incorrect arguments are passed
+
+    # Output the supported options and their usage to the user
+    echo "Usage: configure-openssl-cnf.sh [options]"
+    echo "Options:"
+    echo "  0                     Configure OpenSSL for standard mode"
+    echo "  1                     Configure OpenSSL for PQC testing mode"
+    echo "  --help                Display this help message and exit"
+
+}
+
+#-------------------------------------------------------------------------------------------------------------------------------
+function parse_args() {
+    # Function for parsing the flags passed to the script when called
+
+    # Check if the help flag is passed at any position
+    if [[ "$*" =~ --help ]]; then
+        output_help_message
+        exit 0
+    fi
+
+    # Set the default option selected flag 
+    mode_selected="False"
+
+    # Check if custom control port flags have been passed to the script
+    while [[ $# -gt 0 ]]; do
+
+        case "$1" in
+
+            0)
+
+                # Set the configure mode if no mode has been yet
+                if [ "$mode_selected" == "False" ]; then
+                    configure_mode=0
+                    mode_selected="True"
+
+                else
+                    echo "[ERROR] - Only one mode can be selected at a time"
+                    exit 1
+                fi
+
+                shift
+                ;;
+
+            1)
+                # Set the configure mode if no mode has been yet
+                if [ "$mode_selected" == "False" ]; then
+                    configure_mode=1
+                    mode_selected="True"
+
+                else
+                    echo "[ERROR] - Only one mode can be selected at a time"
+                    exit 1
+                fi
+
+                shift
+                ;;
+
+            *)
+                echo -e "[ERROR] - Invalid argument passed to configure-openssl-cnf.sh"
+                output_help_message
+                exit 1
+                ;;
+
+        esac
+
+    done
+
+}
+
+#-------------------------------------------------------------------------------------------------------------------------------
 function setup_base_env() {
     # Function for setting up the basic global variables for the test suite. This includes setting the root directory
     # and the global library paths for the test suite. The function establishes the root path by determining the path of the script and 
@@ -67,7 +139,6 @@ function configure_conf_statements() {
 
     # Declare required local variables
     local conf_path="$openssl_path/openssl.cnf"
-    local configure_mode="$1"
 
     # Set the configurations based on the configuration mode passed
     if [ "$configure_mode" -eq 0 ]; then
@@ -92,18 +163,25 @@ function configure_conf_statements() {
 function main() {
     # Main function for controlling the utility script
 
+    # Declare the configuration mode variable
+    configure_mode=""
+
+    # Ensure that arguments have been passed to the script and parse them
+    if [[ $# -gt 0 ]]; then
+        parse_args "$@"
+
+    else
+        echo "[ERROR] - No arguments passed to configure-openssl-cnf.sh"
+        output_help_message
+        exit 1
+
+    fi
+
     # Setting up the base environment for the test suite
     setup_base_env
 
-    # Check if the correct number of arguments is passed
-    if [ "$#" -ne 1 ]; then
-        echo -e "\nerror in script, incorrect number of arguments passed to configure-openssl-cnf.sh\n"
-        sleep 1
-        exit 1
-    fi
-
     # Call configure conf file function and pass mode
-    configure_conf_statements "$1"
+    configure_conf_statements
 
 }
 main "$@"

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -30,6 +30,19 @@ openssl_lib_dir = ""
 oqs_provider_src_dir = ""
 
 #-----------------------------------------------------------------------------------------------------------
+def output_help_message():
+    """ # Helper function for outputting the help message to the user when called or when incorrect arguments are passed """
+
+    # Output the supported options and their usage to the user
+    print("get_algorithms.py [options]")
+    print("\nOptions:")
+    print("1        Get the algorithms supported by the Liboqs library")
+    print("2        Get the algorithms supported by the Liboqs library and the OQS-Provider library")
+    print("3        Get the algorithms supported by the OQS-Provider library")
+    print("4        Parse the ALGORITHMS.md file of the OQS-Provider library to get the total number of algorithms supported")
+    print("--help   Output the help message to the user")
+
+#-----------------------------------------------------------------------------------------------------------
 def setup_base_env():
     """ Function for setting up the basic global variables for the test suite. This includes setting the root directory
         and the global library paths for the test suite. The function establishes the root path by determining the path of the script and 
@@ -310,6 +323,11 @@ def parse_oqs_provider_algorithms_md():
 def main():
     """ Main function for controlling the utility script. The function will determine which algorithms 
         are required based on the argument passed to the script """
+    
+    # Check if the help flag was passed before continuing
+    if "--help" in sys.argv:
+        output_help_message()
+        sys.exit(0)
 
     # Ensure a valid argument was passed to the utility script
     if len(sys.argv) == 2:

--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,26 @@ openssl_source="$tmp_dir/openssl-3.4.1"
 install_type=0 # 0=Liboqs-only, 1=Liboqs+OQS-Provider, 2=OQS-Provider-only
 
 #-------------------------------------------------------------------------------------------------------------------------------
+function output_help_message() {
+    # Helper function for outputting the help message to the user when called or when incorrect arguments are passed
+
+    # Output the supported options and their usage to the user
+    echo "Usage: setup.sh [options]"
+    echo "Options:"
+    echo "  --safe-setup                  Use the last tested versions of the OQS libraries"
+    echo "  --set-speed-new-value=[int]   Set a new value to be set for the hardcoded MAX_KEM_NUM/MAX_SIG_NUM values in the OpenSSL speed.c file"
+    echo "  --help                        Display the help message"
+
+}
+
+#-------------------------------------------------------------------------------------------------------------------------------
 function parse_args() {
+
+    # Check if the help flag is passed at any position
+    if [[ "$*" =~ --help ]]; then
+        output_help_message
+        exit 0
+    fi
 
     # Check if custom control port flags have been passed to the script
     while [[ $# -gt 0 ]]; do
@@ -51,26 +70,26 @@ function parse_args() {
                 # Set the user-defined speed flag and value
                 user_defined_speed_flag=1
                 user_defined_speed_value="${1#*=}"
+
+                # Ensure that the user-defined value is a valid integer if the user-defined speed flag is set
+                if [ "$user_defined_speed_flag" -eq 1 ] && ! [[ "$user_defined_speed_value" =~ ^[0-9]+$ ]]; then
+                    echo -e "[ERROR] - The user-defined speed value must be a valid integer, please verify the value and rerun the setup script\n"
+                    output_help_message
+                    exit 1
+                fi
+
                 shift
                 ;;
 
             *)
                 echo "[ERROR] - Unknown option: $1"
-                echo "Valid options are:"
-                echo "  --safe-setup                  Use the last tested versions of the OQS libraries"
-                echo "  --set-speed-new-value=[int]   Set a new value to be set for the hardcoded MAX_KEM_NUM/MAX_SIG_NUM values in the OpenSSL speed.c file"
+                output_help_message
                 exit 1
                 ;;
 
         esac
 
     done
-
-    # Ensure that the user-defined value is a valid integer if the user-defined speed flag is set
-    if [ "$user_defined_speed_flag" -eq 1 ] && ! [[ "$user_defined_speed_value" =~ ^[0-9]+$ ]]; then
-        echo -e "[ERROR] - The user-defined speed value must be a valid integer, please verify the value and rerun the setup script"
-        exit 1
-    fi
 
 }
 
@@ -932,7 +951,8 @@ function main() {
                 py_exit_status=$?
                 cd $root_dir
 
-                break;;
+                break
+                ;;
             
             2)
                 # Outputting selection choice
@@ -957,7 +977,9 @@ function main() {
                 $python_bin "get_algorithms.py" "2"
                 py_exit_status=$?
                 cd $root_dir
-                break;;
+
+                break
+                ;;
 
             3)
                 # Outputting selection choice
@@ -1002,7 +1024,9 @@ function main() {
                 $python_bin "get_algorithms.py" "$alg_list_flag"
                 py_exit_status=$?
                 cd $root_dir
-                break;;
+
+                break
+                ;;
 
             4)
                 echo "Exiting Setup!"


### PR DESCRIPTION
## Summary
Several scripts that accept flags or arguments currently lack a `--help` flag, making it harder for users to understand their usage without referring to external documentation or the script source. To improve clarity and consistency across the project, a standardized help flag needs to be implemented. This will involve modifying relevant scripts to handle a `--help` argument and display structured usage information.

## Task Details
- Identify scripts which take arguments and add a --help flag to scripts that accept arguments.
- Ensure help messages include usage details and follow a consistent format.
- Verify functionality and update documentation if needed.