### PR TITLE
Fix ARM PMU Access Loss After Reboot on Some Raspberry Pi Devices 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:


### PR DESCRIPTION
## Summary
On older Raspberry Pi models, access to the ARM Performance Monitoring Unit (PMU) provided by the PQAX dependency does not always persist after a reboot. This causes Liboqs scripts that rely on PMU access to fail at runtime. The issue appears to be specific to older hardware and may relate to kernel configuration, permissions, or boot-time initialisation. It will need to be tested across multiple Raspberry Pi generations to ensure a complete fix.

## Task Details
Investigate why PMU access is lost after reboot on older Raspberry Pis
Make any adjustments needed to ensure user access to the ARM PMU is maintained
Add exception handling in liboqs scripts for missing PMU access
Test across different Raspberry Pi generations and environments to confirm the issue is resolved
Update documentation with any required setup or configuration steps