### PR TITLE
Fix ARM PMU Access Loss After Reboot on Some Raspberry Pi Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
 - [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/setup.sh
+++ b/setup.sh
@@ -795,13 +795,22 @@ function enable_arm_pmu() {
     make
     make_status=$?
     make install
+    make_install_status=$?
     cd $root_dir
 
-    # Setting the enabled PMU flag if the make command was successful
-    if [ "$make_status" -eq 0 ]; then
+    # Check if the make and make install commands were successful
+    if [ "$make_status" -ne 0 ] || [ "$make_install_status" -ne 0 ]; then
+        echo -e "\nPMU build failed, please check the system and try again\n"
+        exit 1
+    fi
+
+    # Ensure that the system has user access to the ARM PMU
+    if lsmod | grep -q 'enable_ccr'; then
         enabled_pmu=1
     else
+        echo "[ERROR] - The enable_ccr module is not loaded, please verify the installation and rerun the setup script"
         enabled_pmu=0
+        exit 1
     fi
 
 }


### PR DESCRIPTION
## Summary
On older Raspberry Pi models, access to the ARM Performance Monitoring Unit (PMU) provided by the PQAX dependency does not always persist after a reboot. This causes Liboqs scripts that rely on PMU access to fail at runtime. The issue appears to be specific to older hardware and may relate to kernel configuration, permissions, or boot-time initialisation. It will need to be tested across multiple Raspberry Pi generations to ensure a complete fix.

## Task Details

- Investigate why PMU access is lost after reboot on older Raspberry Pis
- Make any adjustments needed to ensure user access to the ARM PMU is maintained
- Add exception handling in liboqs scripts for missing PMU access
- Test across different Raspberry Pi generations and environments to confirm the issue is resolved
- Update documentation with any required setup or configuration steps
