### PR TITLE
 Fix HQC not being enabled by default in Liboqs builds

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,26 @@
+
+# Project Disclaimer
+
+## General Disclaimer
+This project is intended solely for research and benchmarking purposes. The tools and scripts provided in this repository are designed to evaluate the performance characteristics of Post-Quantum Cryptography (PQC) algorithms in controlled environments. They are not intended for production use or security-critical applications.
+
+The maintainers of this project assume no liability for any consequences resulting from the use or misuse of this repository or its components.
+
+Users are expected to understand the implications of enabling, modifying, or extending any parts of the framework, especially when integrating with cryptographic libraries and systems.
+
+## HQC Algorithm Inclusion Disclaimer
+The HQC KEM algorithms are disabled by default in recent versions of the Liboqs library due to a known security issue that breaks IND-CCA2 guarantees under specific attack models.
+
+Despite this, the PQC Evaluation Tools framework provides an optional mechanism to enable HQC algorithms for the sole purpose of performance testing. When using the `--enable-hqc-algs` flag during setup, users will receive a clear warning and must explicitly confirm before HQC is included in the benchmarking environment.
+
+If HQC is enabled:
+
+- It must only be used within the provided testing tools.
+- It must not be used in any production systems or real-world cryptographic deployments.
+
+Enabling HQC is done at the user's own risk, and the project maintainers accept no responsibility for any issues arising from its inclusion.
+
+For more information, see:
+- [Liboqs Pull Request #2122](https://github.com/open-quantum-safe/liboqs/pull/2122)
+- [Liboqs Issue #2118](https://github.com/open-quantum-safe/liboqs/issues/2118)
+- [PQC-Evaluation-Tools Issue #46](https://github.com/crt26/pqc-evaluation-tools/issues/46)

--- a/DISCLAIMER.txt
+++ b/DISCLAIMER.txt
@@ -1,8 +1,0 @@
-Older version of liboqs (0.7.2) will contain algorithms that have been deemed insecure and older versions of current algorithms.
-
-The purpose behind including an older version is to allow the benchmarking of algorithms that are no longer being considered by NIST for academic purposes.
-Please keep this in behind when performing analysis of results.
-
-
-This dependency-libs directory will hold the pqax directory to allow for the use of the ARM PMU. Information for this library can be found at:
-https://github.com/mupq/pqax#enable-access-to-performance-counters

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Callum Turino
+Copyright (c) 2023-2025 Callum Turino
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The automated testing tool is currently only supported in the following environm
 ### Tested Dependency Libraries <!-- omit from toc -->
 This version of the repository has been fully tested with the following library versions:
 
-- Liboqs Version 0.12.0
+- Liboqs Version 0.13.0
 
 - OQS Provider Version 0.8.0
 
@@ -78,7 +78,9 @@ The repository is configured to pull the latest versions of the OQS projects whi
 
 However, as the OQS libraries are still developing projects, if any major changes have occurred to their code bases, this project's automation scripts may not be able to accommodate this. If this does happen, please report an issue to this repositories GitHub page where it will be addressed as soon as possible. In the meantime, it is possible to change the versions of the OQS libraries used by the benchmarking suite. This is detailed further in the [Installation Instructions](#installation-instructions) section.
 
-> Notice: Memory profiling for Falcon algorithm variants is currently non-functional on **ARM** systems due to issues with the scheme and the Valgrind Massif tool. Please see the [bug report](https://github.com/open-quantum-safe/liboqs/issues/1761) for details. Testing and parsing remain fully functional for all other algorithms.
+> **Notice 1:** The HQC KEM algorithms are disabled by default in recent Liboqs versions due to a disclosed IND-CCA2 vulnerability. For benchmarking purposes, the setup process includes an optional flag to enable HQC, accompanied by a user confirmation prompt and warning. For instructions on enabling HQC, see the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md), and refer to the [Disclaimer Document](./DISCLAIMER.md) for more information on this issue.
+
+> **Notice 2:** Memory profiling for Falcon algorithm variants is currently non-functional on **ARM** systems due to issues with the scheme and the Valgrind Massif tool. Please see the [bug report](https://github.com/open-quantum-safe/liboqs/issues/1761) for details. Testing and parsing remain fully functional for all other algorithms.
 
 ## Installation Instructions
 The standard setup process uses the latest versions of the OQS libraries and performs automatic system detection and installation of the benchmarking suite. It supports various installation modes that determine which OQS libraries are downloaded and built, depending on your environment.
@@ -148,7 +150,12 @@ touch .pqc_eval_dir_marker.tmp
 ```
 
 ### Optional Setup Flags
-For advanced setup options, including `safe-mode` for using the last tested versions of the dependency libraries, custom OpenSSL `speed.c` limits, and additional build features, please refer to the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md).
+For advanced setup options, including:
+- `safe-mode` for using the last tested versions of the dependency libraries,
+- Custom OpenSSL `speed.c` limits, 
+- Enabling HQC algorithms in Liboqs
+ 
+Please refer to the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md).
 
 ## Automated Testing Tools
 The repository provides two categories of automated benchmarking:
@@ -162,14 +169,11 @@ The testing tools are located in the `scripts/test-scripts` directory and are fu
 ### Liboqs Performance Testing
 This tool benchmarks CPU and memory usage for various PQC algorithms supported by the Liboqs library. It produces detailed performance metrics for each tested algorithm.
 
-The test script can be executed using the following command:
-```
-./full-liboqs-test.sh
-```
-
 For detailed usage instructions, please refer to:
 
 [Automated Liboqs Performance Testing Instructions](docs/testing-tools-usage/liboqs-performance-testing.md)
+
+**Note:** HQC KEM algorithms are disabled by default in the latest Liboqs version due to a known vulnerability. The main setup script provides an option to enable HQC for benchmarking if required. Please refer to the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md) for more information.
 
 ### OQS-Provider TLS Performance Testing
 This tool is focused on benchmarking the performance of PQC and Hybrid-PQC algorithms when integrated within OpenSSL (3.4.1) via the OQS-Provider library.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
 - [ ] Functioning State*
-- [x] Up to date documentation
+- [ ] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Utility script for cleaning up project files produced during PQC benchmarking.

--- a/docs/advanced-setup-configuration.md
+++ b/docs/advanced-setup-configuration.md
@@ -2,8 +2,8 @@
 This document outlines additional configuration options when running the `setup.sh` script. The main setup supports the following advanced configurations when called:
 
 - Safe Setup
-
 - Manually Adjusting OpenSSL's speed Tool Hardcoded Limits
+- Enabling HQC KEM Algorithms in Liboqs
 
 ## Safe Setup
 If you encounter compatibility issues with the latest versions of the OQS libraries, you can use **Safe Setup mode**, which installs the last known working versions tested with this project.
@@ -28,3 +28,27 @@ By default, the main setup script will attempt to detect and patch these values 
 Replace [integer] with the desired value. The setup script will then patch the speed.c source file to set both `MAX_KEM_NUM` and `MAX_SIG_NUM` to this value before compiling OpenSSL.
 
 For further details on this issue and the future plans to address the problem, please refer to this [git issue](https://github.com/crt26/pqc-evaluation-tools/issues/25) on the repositories page.
+
+## Enabling HQC KEM Algorithms in Liboqs
+Recent versions of the Liboqs library disable the HQC KEM algorithms by default due to a known **IND-CCA2 vulnerability**. However, the PQC Evaluation Tools framework allows users to optionally re-enable HQC algorithms **for benchmarking purposes only**. This acts as a temporary solution until the updated implementation of HQC is addeed to Liboqs in version 0.14.0. 
+
+To enable HQC, use the following setup flag:
+
+```
+./setup.sh --enable-hqc-algs
+```
+
+When this flag is provided, the setup script will present a clear warning explaining the associated risks of enabling HQC. The user must then explicitly confirm before HQC support is included in the Liboqs build.
+
+If enabled, the setup script will:
+- Pass the appropriate CMake flag to Liboqs to include HQC algorithms.
+- Create a temporary marker file (`.hqc_enabled.flag`) in the `tmp` directory to track that HQC is enabled.
+- Ensure internal tools, such as the `get_algorithms.py` utility script, detect this marker and include HQC in the generated algorithm list text files.
+
+**Important:** If HQC is enabled, the resulting Liboqs build should only be used within this project’s benchmarking tools. It must not be used for anything else other than its intended purpose.
+
+For additional context, please see:
+- [Liboqs Pull Request #2122](https://github.com/open-quantum-safe/liboqs/pull/2122)
+- [Liboqs Issue #2118](https://github.com/open-quantum-safe/liboqs/issues/2118)
+- [PQC-Evaluation-Tools Issue #46](https://github.com/crt26/pqc-evaluation-tools/issues/46)
+- [Disclaimer Document](../DISCLAIMER.md)

--- a/docs/developer-information/project-scripts.md
+++ b/docs/developer-information/project-scripts.md
@@ -69,7 +69,8 @@ The script is run interactively but supports the following optional arguments fo
 
 ```
 --safe-setup                   Use last-tested commits of all libraries  
---set-speed-new-value=<int>    Manually set MAX_KEM_NUM/MAX_SIG_NUM in speed.c  
+--set-speed-new-value=<int>    Manually set MAX_KEM_NUM/MAX_SIG_NUM in speed.c
+--enable-hqc-algs              Enable HQC KEM algorithms in Liboqs (default: disabled due to security concerns)  
 ```
 
 For further information on the main setup script's usage, please refer to the main [README](../../README.md) file.

--- a/docs/testing-tools-usage/liboqs-performance-testing.md
+++ b/docs/testing-tools-usage/liboqs-performance-testing.md
@@ -6,18 +6,20 @@ This guide provides detailed instructions for using the automated Post-Quantum C
 The tool outputs raw performance metrics in CSV and text formats, which are later parsed using Python scripts for easier interpretation and analysis.
 
 ### Contents <!-- omit from toc -->
-- [Supported Hardware](#supported-hardware)
+- [Supported Hardware and Software](#supported-hardware-and-software)
 - [Performing PQC Computational Performance Testing](#performing-pqc-computational-performance-testing)
   - [Running the Liboqs Testing Tool](#running-the-liboqs-testing-tool)
   - [Configuring Testing Parameters](#configuring-testing-parameters)
 - [Outputted Results](#outputted-results)
 - [Useful External Documentation](#useful-external-documentation)
 
-## Supported Hardware
+## Supported Hardware and Software
 The automated testing tool is currently only supported on the following devices:
 
 - x86 Linux Machines using a Debian-based operating system
 - ARM Linux devices using a 64-bit Debian based Operating System
+
+**Notice:** The HQC KEM algorithms are disabled by default in recent Liboqs versions due to a disclosed IND-CCA2 vulnerability. For benchmarking purposes, the setup process includes an optional flag to enable HQC, accompanied by a user confirmation prompt and warning. For instructions on enabling HQC, see the [Advanced Setup Configuration Guide](../advanced-setup-configuration.md), and refer to the [Disclaimer Document](../../DISCLAIMER.md) for more information on this issue.
 
 ## Performing PQC Computational Performance Testing
 

--- a/scripts/parsing-scripts/liboqs_parse.py
+++ b/scripts/parsing-scripts/liboqs_parse.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 Callum Turino
+Copyright (c) 2023-2025 Callum Turino
 SPDX-License-Identifier: MIT
 
 Liboqs result parsing script for PQC performance benchmarking.  

--- a/scripts/parsing-scripts/oqs_provider_parse.py
+++ b/scripts/parsing-scripts/oqs_provider_parse.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 Callum Turino
+Copyright (c) 2023-2025 Callum Turino
 SPDX-License-Identifier: MIT
 
 OQS-Provider result parsing script for PQC TLS performance benchmarking.  

--- a/scripts/parsing-scripts/parse_results.py
+++ b/scripts/parsing-scripts/parse_results.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 Callum Turino
+Copyright (c) 2023-2025 Callum Turino
 SPDX-License-Identifier: MIT
 
 Controller script for parsing PQC performance results produced by the Liboqs and OQS-Provider testing tools.

--- a/scripts/parsing-scripts/results_averager.py
+++ b/scripts/parsing-scripts/results_averager.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 Callum Turino
+Copyright (c) 2023-2025 Callum Turino
 SPDX-License-Identifier: MIT
 
 Result averaging module for PQC benchmarking tools. Defines classes for calculating average metrics 

--- a/scripts/test-scripts/full-liboqs-test.sh
+++ b/scripts/test-scripts/full-liboqs-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Script for controlling the Liboqs PQC computational performance benchmarking. It accepts test parameters 

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Script for controlling the OQS-Provider TLS benchmarking suite using OpenSSL 3.4.1. It handles the configuration 

--- a/scripts/test-scripts/oqsprovider-generate-keys.sh
+++ b/scripts/test-scripts/oqsprovider-generate-keys.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Script for generating all the server certificates and keys required for the TLS handshake benchmarking suite. 

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Client-side script for executing TLS handshake performance tests in coordination with a remote server. 

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Server-side script for executing TLS handshake performance tests in coordination with a remote client. 

--- a/scripts/test-scripts/oqsprovider-test-speed.sh
+++ b/scripts/test-scripts/oqsprovider-test-speed.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Script executed from the client machine to benchmark the computational performance of PQC, Hybrid-PQC, and 

--- a/scripts/utility-scripts/configure-openssl-cnf.sh
+++ b/scripts/utility-scripts/configure-openssl-cnf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # Utility script for toggling the OpenSSL configuration settings in the openssl.cnf file to enable or 

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -179,6 +179,10 @@ def get_liboqs_algs():
                     alg_list_file = os.path.join(output_dir, "kem-algs.txt")
                 else:
                     alg_list_file = os.path.join(output_dir, "sig-algs.txt")
+
+                # Filter out HQC KEM algorithms from the list if the HQC enabled flag is not set (temp fix for HQC bug)
+                if not os.path.exists(os.path.join(root_dir, "tmp", ".hqc_enabled.flag")):
+                    algs = [alg for alg in algs if not alg.startswith("HQC")]
                 
                 # Write out the algorithms to the list file
                 write_to_file(algs, alg_list_file)

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 Callum Turino
+Copyright (c) 2023-2025 Callum Turino
 SPDX-License-Identifier: MIT
 
 Utility script for retrieving supported cryptographic algorithms from the Liboqs and OQS-Provider libraries. 

--- a/setup.sh
+++ b/setup.sh
@@ -74,29 +74,34 @@ function get_user_yes_no() {
 #-------------------------------------------------------------------------------------------------------------------------------
 function confirm_enable_hqc_algs() {
     # Temporary helper function for warning the user about the disabled HQC KEM algorithms as discussed in issue 
-    # (https://github.com/crt26/pqc-evaluation-tools/issues/46). The function will warn the user about the disabled HQC KEM algorithms
-    # and why this is has been done, before offering to enable them if the user wishes to do so. This function will be removed in the future
-    # when Liboqs version 0.14.0 is released and the HQC KEM algorithms are enabled by default.
+    # (https://github.com/crt26/pqc-evaluation-tools/issues/46). The function will display a security warning and provide 
+    # background information about why HQC KEM algorithms are disabled by default in Liboqs. It then prompts the user to 
+    # decide whether to proceed with enabling HQC for benchmarking purposes. This function will be removed in the future 
+    # when Liboqs version 0.14.0 is released and the HQC KEM algorithms are re-enabled by default.
 
     # Output the current task and the warning message to the terminal
     echo -e "\nEnable HQC KEM Algorithms Flag Detected:\n"
-    echo -e "[WARNING] - The Liboqs library has disabled the HQC KEM algorithms by default due to a recently disclosed"
-    echo "security vulnerability affecting IND-CCA2 security guarantees. As this projects primary focus is on benchmarking"
-    echo -e "rather than PQC algorithm deployment, the HQC algorithms can be enabled for testing purposes.\n"
-    echo "Please note, that is is done at your own risk and the project does not take any responsibility for any issues that may arise from this."
-    echo -e "\nFor further information on this, please refer to:"
-    echo "- Liboqs issue: https://github.com/open-quantum-safe/liboqs/issues/2118"
+
+    echo -e "[WARNING] - The Liboqs library disables HQC KEM algorithms by default due to a recently disclosed"
+    echo -e "security vulnerability that compromises their IND-CCA2 security guarantees. Since this project's primary"
+    echo -e "focus is benchmarking (not production deployment), HQC can be still be enabled for performance testing purposes.\n"
+
+    echo -e "For more details, see:"
+    echo -e "- Liboqs issue: https://github.com/open-quantum-safe/liboqs/issues/2118"
     echo -e "- pqc-evaluation-tools issue: https://github.com/crt26/pqc-evaluation-tools/issues/46\n"
+
+    echo -e "Please note: Enabling HQC is done at your own risk. This project assumes no responsibility for"
+    echo -e "any consequences that may result from using these algorithms.\n"
 
     # Determine if the user wishes to continue with enabling the HQC KEM algorithms
     get_user_yes_no "Would you like continue with enabling the HQC KEM algorithms in the Liboqs library?"
 
     # Check the user response and set the enable_hqc flag accordingly
     if [ "$user_y_n_response" -eq 1 ]; then
-        echo -e "[NOTICE] - HQC KEM algorithms will be enabled in the Liboqs library build process\n"
+        echo -e "\n[NOTICE] - HQC KEM algorithms will be enabled in the Liboqs library build process\n"
         enable_hqc=1
     else
-        echo -e "[NOTICE] - HQC KEM algorithms will not be enabled in the Liboqs library build process\n"
+        echo -e "\n[NOTICE] - HQC KEM algorithms will not be enabled in the Liboqs library build process\n"
         enable_hqc=0
     fi
 
@@ -111,7 +116,7 @@ function output_help_message() {
     echo "Options:"
     echo "  --safe-setup                  Use the last tested versions of the OQS libraries"
     echo "  --set-speed-new-value=[int]   Set a new value to be set for the hardcoded MAX_KEM_NUM/MAX_SIG_NUM values in the OpenSSL speed.c file"
-    echo "  --enable-hqc-algs             Enable HQC KEM algorithms in Liboqs (default: disabled due to security concerns)"
+    echo "  --enable-hqc-algs             Enable HQC KEM algorithms in Liboqs (default: disabled due to security concerns)" # temp option for hqc bug fix
     echo "  --help                        Display the help message"
 
 }
@@ -1047,12 +1052,16 @@ function main() {
     if [ "$#" -gt 0 ]; then
         parse_args "$@"
     fi
+
+    # Output current task to the terminal
+    echo "######################"
+    echo "Install Type Selection"
+    echo -e "######################\n"
     
     # Get the install type selection from the user
     while true; do
 
         # Output the install type options to the user
-        echo -e "Install Type Selection: \n"
         echo "Please Select one of the following build options"
         echo "1 - Build Liboqs Library Only"
         echo "2 - Build OQS-Provider and Liboqs Library"

--- a/setup.sh
+++ b/setup.sh
@@ -331,7 +331,7 @@ function download_libraries() {
 
             # Clone Liboqs and checkout to the last tested version
             git clone https://github.com/open-quantum-safe/liboqs.git $liboqs_source
-            cd $liboqs_source && git checkout "f4b96220e4bd208895172acc4fedb5a191d9f5b1"
+            cd $liboqs_source && git checkout "b75bfb8c56d23a92227b04c096f0264b992de874"
             cd $root_dir
 
         else
@@ -363,7 +363,7 @@ function download_libraries() {
 
             # Clone OQS-Provider and checkout to the last tested version
             git clone https://github.com/open-quantum-safe/oqs-provider.git $oqs_provider_source >> /dev/null
-            cd $oqs_provider_source && git checkout "ec1e8431f92b52e5d437107a37dbe3408649e8c3"
+            cd $oqs_provider_source && git checkout "c5d19140a23d40d472881370c04cb2ddd7279f01"
             cd $root_dir
 
         else

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025 Callum Turino
+# Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
 # This script automates the setup process for the PQC-evaluation-tools benchmarking suite. It provides options to build and configure


### PR DESCRIPTION
## Summary
Although HQC appears in the list of supported algorithms in Liboqs, it is currently disabled by default as of [version 0.13.0](https://github.com/open-quantum-safe/liboqs/releases/tag/0.13.0) due to a [known security vulnerability](https://github.com/open-quantum-safe/liboqs/pull/2117) affecting its IND-CCA2 guarantees. This results in confusing behaviour where HQC is listed but fails at runtime with errors like “HQC-128 not enabled.” This has affected both x86 and ARM setups.

Since the primary goal of this project is benchmarking, not secure deployment, it is reasonable to allow users to optionally re-enable HQC during setup, with appropriate warnings and documentation.

Additionally, the `--safe-setup` mode currently pulls a version of Liboqs that fails to build, which prevents this fallback setup from working as expected.

## Task Details
- Add a user-facing setup option to re-enable HQC explicitly
- Update project documentation to explain the reasoning and link to upstream discussions
- Ensure the option works across automated and safe setup modes
- Fix the `--safe-setup` path to build successfully
- Design the solution to be temporary and easily removable when HQC is re-integrated upstream (expected in Liboqs 0.14.0)