### PR TITLE
Upgrade OpenSSL Dependency to Version 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ For full details on the project's development and the current development task l
 ## Repository Overview <!-- omit from toc -->
 
 ### Project Description
-This repository provides an automated and comprehensive evaluation framework for benchmarking Post-Quantum Cryptography (PQC) algorithms. It is designed for researchers and developers looking to evaluate the feasibility of integrating PQC into their environments. It simplifies the setup, testing, and parsing of PQC computational and networking performance data across x86 and ARM systems.
+This repository provides an automated and comprehensive evaluation framework for benchmarking Post-Quantum Cryptography (PQC) algorithms. It is designed for researchers and developers looking to evaluate the feasibility of integrating PQC into their environments. It simplifies the setup, testing, and parsing of PQC computational and networking performance data across x86 and ARM systems through a series of dedicated automation scripts.
 
-The framework includes scripts to automate dependency building, test execution, and result parsing. It currently utilises the [Open Quantum Safe (OQS)](https://openquantumsafe.org/) project's `Liboqs` and `OQS-Provider` libraries to gather this performance data, with future goals to integrate additional PQC libraries. It also provides automated mechanisms for testing PQC TLS handshake performance across physical or virtual networks, providing valuable insight into real-world environment testing. Results are outputted as raw CSV files that can be parsed using the provided Python parsing scripts to provide detailed metrics and averages ready for analysis.
+It currently utilises the [Open Quantum Safe (OQS)](https://openquantumsafe.org/) project's `Liboqs` and `OQS-Provider` libraries, alongside PQC implementation available in OpenSSL 3.5.0, with future goals to integrate additional PQC libraries. The framework also provides automated mechanisms for testing PQC TLS handshake performance across physical or virtual networks, providing valuable insight into real-world environment testing. Results are outputted as raw CSV files that can be parsed using the provided Python parsing scripts to provide detailed metrics and averages ready for analysis.
 
 ### Supported Automation Functionality
 The project provides automation for:
@@ -25,7 +25,7 @@ The project provides automation for:
 
 - Collecting PQC computational performance data, including CPU and memory usage metrics, using the Liboqs library.
 
-- Gathering networking performance data for PQC schemes integrated into the TLS 1.3 protocol via OpenSSL 3.4.1 and the OQS-Provider libraries.
+- Gathering networking performance data for PQC schemes integrated into the TLS 1.3 protocol using the OpenSSL 3.5.0 and the OQS-Provider libraries.
 
 - Coordinated PQC TLS handshake tests run over the loopback interface or across physical networks between a server and client device.
 
@@ -38,6 +38,7 @@ For details on the project's development and upcoming features, see the project'
 
 ## Contents <!-- omit from toc -->
 - [Supported Hardware and Software](#supported-hardware-and-software)
+- [Supported Crytpographic Algorithms](#supported-crytpographic-algorithms)
 - [Installation Instructions](#installation-instructions)
   - [Cloning the Repository](#cloning-the-repository)
   - [Choosing Installation Mode](#choosing-installation-mode)
@@ -72,15 +73,16 @@ This version of the repository has been fully tested with the following library 
 
 - OQS Provider Version 0.8.0
 
-- OpenSSL Version 3.4.1
+- OpenSSL Version 3.5.0
 
 The repository is configured to pull the latest versions of the OQS projects while maintaining the listed OpenSSL version. This ensures support for the most up-to-date algorithms available from the OQS project. The setup process includes handling changes in the OQS libraries and helping maintain compatibility as updates are released.
 
 However, as the OQS libraries are still developing projects, if any major changes have occurred to their code bases, this project's automation scripts may not be able to accommodate this. If this does happen, please report an issue to this repositories GitHub page where it will be addressed as soon as possible. In the meantime, it is possible to change the versions of the OQS libraries used by the benchmarking suite. This is detailed further in the [Installation Instructions](#installation-instructions) section.
 
-> **Notice 1:** The HQC KEM algorithms are disabled by default in recent Liboqs versions due to a disclosed IND-CCA2 vulnerability. For benchmarking purposes, the setup process includes an optional flag to enable HQC, accompanied by a user confirmation prompt and warning. For instructions on enabling HQC, see the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md), and refer to the [Disclaimer Document](./DISCLAIMER.md) for more information on this issue.
+## Supported Crytpographic Algorithms
+For further information on the classical and PQC algorithms this project provides support for, including information on any exclusions, please refer to the following documentation:
 
-> **Notice 2:** Memory profiling for Falcon algorithm variants is currently non-functional on **ARM** systems due to issues with the scheme and the Valgrind Massif tool. Please see the [bug report](https://github.com/open-quantum-safe/liboqs/issues/1761) for details. Testing and parsing remain fully functional for all other algorithms.
+[Supported Algorithms](docs/supported-algorithms.md)
 
 ## Installation Instructions
 The standard setup process uses the latest versions of the OQS libraries and performs automatic system detection and installation of the benchmarking suite. It supports various installation modes that determine which OQS libraries are downloaded and built, depending on your environment.
@@ -118,7 +120,7 @@ When executing the setup script, you will be prompted to select one of the follo
 
 3. **Build only the OQS-Provider library** – For use after a prior Liboqs installation.
 
-The setup script will also build [OpenSSL 3.4.1](https://www.openssl.org/source/) inside the repository’s `lib` directory. This version is required to support the OQS-Provider and is built separately from the system’s default OpenSSL installation. It will not interfere with system-level binaries.
+The setup script will also build [OpenSSL 3.5.0](https://www.openssl.org/source/) inside the repository’s `lib` directory. This version is required to support the OQS-Provider and is built separately from the system’s default OpenSSL installation. It will not interfere with system-level binaries.
 
 If the installation of the `OQS-Provider` library is selected, the setup script will prompt you to enable two optional features:
 
@@ -160,9 +162,9 @@ Please refer to the [Advanced Setup Configuration Guide](docs/advanced-setup-con
 ## Automated Testing Tools
 The repository provides two categories of automated benchmarking:
 
-- **Liboqs Performance Testing** - Used for gathering PQC computational performance data
+- **Liboqs Performance Testing** - Used for gathering PQC computational performance data using the Liboqs library.
 
-- **OQS-Provider TLS Performance Testing** - Used for gathering PQC TLS 1.3 networking performance benchmarking when integrated into OpenSSL 3.4.1
+- **PQC TLS Performance Testing** - Used for gathering PQC TLS 1.3 networking performance benchmarking using PQC implementation available in the OpenSSL 3.5.0 and OQS-Provider libraries.
 
 The testing tools are located in the `scripts/test-scripts` directory and are fully automated. The tools support multi-machine testing, with the option to assign a machine ID when executing the testing scripts.
 
@@ -173,10 +175,12 @@ For detailed usage instructions, please refer to:
 
 [Automated Liboqs Performance Testing Instructions](docs/testing-tools-usage/liboqs-performance-testing.md)
 
-**Note:** HQC KEM algorithms are disabled by default in the latest Liboqs version due to a known vulnerability. The main setup script provides an option to enable HQC for benchmarking if required. Please refer to the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md) for more information.
+> **Notice 1:** The HQC KEM algorithms are disabled by default in recent Liboqs versions due to a disclosed IND-CCA2 vulnerability. For benchmarking purposes, the setup process includes an optional flag to enable HQC, accompanied by a user confirmation prompt and warning. For instructions on enabling HQC, see the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md), and refer to the [Disclaimer Document](./DISCLAIMER.md) for more information on this issue.
+
+> **Notice 2:** Memory profiling for Falcon algorithm variants is currently non-functional on **ARM** systems due to issues with the scheme and the Valgrind Massif tool. Please see the [bug report](https://github.com/open-quantum-safe/liboqs/issues/1761) for details. Testing and parsing remain fully functional for all other algorithms.
 
 ### OQS-Provider TLS Performance Testing
-This tool is focused on benchmarking the performance of PQC and Hybrid-PQC algorithms when integrated within OpenSSL (3.4.1) via the OQS-Provider library.
+This tool is focused on benchmarking the performance of PQC and Hybrid-PQC algorithms when integrated into TLS 1.3. This is done using the PQC implementations available in OpenSSL 3.5.0 alongside integrating additional PQC schemes into OpenSSL using the OQS-Provider library.
 
 It conducts two types of testing:
 
@@ -189,12 +193,6 @@ Testing can be performed on a single machine or across two machines connected vi
 For detailed usage instructions, please refer to:
 
 [Automated OQS-Provider TLS Performance Testing Instructions](docs/testing-tools-usage/oqsprovider-performance-testing.md)
-
-**Note:** The following signature algorithms are excluded from the automated TLS benchmarking due to known incompatibilities with [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446):
-- UOV-based schemes (e.g., OV_Is, OV_III, and their hybrid variants)
-- CROSSrsdp256small
-
-These algorithms remain available for computational benchmarking using the Liboqs tools.
 
 ### Testing Output Files
 After the testing has been completed, unparsed results will be stored in the `test-data/up-results` directory:
@@ -242,6 +240,7 @@ Please refer to the [Performance Metrics Guide](docs/performance-metrics-guide.m
 - [Liboqs Automated Performance Testing](docs/testing-tools-usage/liboqs-performance-testing.md)
 - [OQS-Provider Automated Performance Testing](docs/testing-tools-usage/oqsprovider-performance-testing.md)
 - [Advanced Setup Configuration](docs/advanced-setup-configuration.md)
+- [Supported Algorithms](docs/supported-algorithms.md)
 - [Project Scripts](docs/developer-information/project-scripts.md)
 - [Repository Structure](docs/developer-information/repository-directory-structure.md)
 - [Performance Metrics Guide](docs/performance-metrics-guide.md)
@@ -259,7 +258,7 @@ The information provided in the internal documentation is also available through
 - [OQS-Provider GitHub Page](https://github.com/open-quantum-safe/oqs-provider)
 - [Latest Liboqs Release Notes](https://github.com/open-quantum-safe/liboqs/blob/main/RELEASE.md)
 - [Latest OQS-Provider Release Notes](https://github.com/open-quantum-safe/oqs-provider/blob/main/RELEASE.md)
-- [OpenSSL(3.4.1) Documentation](https://docs.openssl.org/3.4/)
+- [OpenSSL(3.5.0) Documentation](https://docs.openssl.org/3.5/)
 - [TLS 1.3 RFC 8446](https://www.rfc-editor.org/rfc/rfc8446)
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -5,7 +5,7 @@
 
 # Utility script for cleaning up project files produced during PQC benchmarking.
 # Provides options to uninstall the OQS-Provider libraries, clear old benchmarking results and generated TLS keys, or perform both actions.
-# Uninstalling will remove the Liboqs, OQS-Provider, and OpenSSL 3.4.1 installations from the system.
+# Uninstalling will remove the Liboqs, OQS-Provider, and OpenSSL 3.5.0 installations from the system.
 # Clearing results will remove test outputs and key material under the test-data directory.
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -46,14 +46,14 @@ function setup_base_env() {
     test_data_dir="$root_dir/test-data"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     liboqs_path="$libs_dir/liboqs"
     oqs_provider_path="$libs_dir/oqs-provider"
 
     # Declaring the global source-code directory path variables
     liboqs_source="$tmp_dir/liboqs-source"
     oqs_provider_source="$tmp_dir/oqs-provider-source"
-    openssl_source="$tmp_dir/openssl-3.4.1"
+    openssl_source="$tmp_dir/openssl-3.5.0"
 
     # Declaring the global test-data directory path variables
     test_data_results="$test_data_dir/results"
@@ -81,7 +81,7 @@ function select_uninstall_mode() {
         echo -e "\nPlease Select one of the following uninstall options"
         echo "1 - Uninstall Liboqs Library Only"
         echo "2 - Uninstall OQS-Provider Library only"
-        echo "3 - Uninstall OpenSSL 3.4.1 Only"
+        echo "3 - Uninstall OpenSSL 3.5.0 Only"
         echo "4 - Uninstall all Libraries"
         echo "5 - Exit Setup"
 
@@ -107,9 +107,9 @@ function select_uninstall_mode() {
                 break;;
 
             3)
-                # Uninstall OpenSSL 3.4.1 only
+                # Uninstall OpenSSL 3.5.0 only
                 rm -rf "$openssl_path"
-                echo -e "\nOpenSSL 3.4.1 Uninstalled"
+                echo -e "\nOpenSSL 3.5.0 Uninstalled"
                 break;;
 
             4)

--- a/docs/developer-information/project-scripts.md
+++ b/docs/developer-information/project-scripts.md
@@ -49,7 +49,7 @@ Key tasks performed include:
 
 - Installing all required system and Python dependencies (e.g., OpenSSL dev packages, CMake, Valgrind)
 
-- Downloading and compiling OpenSSL 3.4.1
+- Downloading and compiling OpenSSL 3.5.0
 
 - Cloning and building specific or last-tested versions of Liboqs and OQS-Provider
 
@@ -112,21 +112,30 @@ python3 get_algorithms.py 1
 ```
 
 ### configure-openssl-cnf.sh
-This utility script modifies the OpenSSL 3.4.1 configuration file by commenting or uncommenting lines that define the default cryptographic groups. This adjustment is required for successful key generation and TLS handshake testing using the OQS-Provider. It is highly recommended to avoid manually calling this script to avoid any potential issues with misconfiguration in the `openssl.cnf` file. However, if issues do occur, it is advised to re-run the automatic setup process or restore a backup of the previous conf file's state.
+This utility script manages the modification of the OpenSSL 3.5.0 openssl.cnf configuration file to support different stages of the PQC testing pipeline. It adjusts cryptographic provider settings and default group directives as required for:
 
-The automated scripts mainly use this script, however it can be called manually using the following commands:
+- Initial setup
 
-**configure-openssl-cnf.sh - (Comment out Default Group Configurations):**
+- Key generation benchmarking
 
-```
-./configure-openssl-cnf.sh 0
-```
+- TLS handshake benchmarking
 
-**configure-openssl-cnf.sh - (Uncomment out Default Group Configurations):**
+These adjustments ensure compatibility with both OpenSSL's native PQC support and the OQS-Provider, depending on the testing context.
 
-```
-./configure-openssl-cnf.sh 1
-```
+**Important:** It is strongly recommended that this script be used only as part of the automated testing framework. Manual use should be limited to recovery or debugging, as improper configuration may result in broken provider loading or handshake failures.
+
+When called, the utility script accepts the following arguments:
+
+| Argument | Functionality                                                                                                                                                                             |
+|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `0`      | Performs initial setup by appending OQS-Provider-related directives to the `openssl.cnf` file. **This should only ever be called during setup when modifying the default OpenSSL conf file.** |
+| `1`      | Configures the OpenSSL environment for **key generation benchmarking** by commenting out PQC-related configuration lines.                                                                 |
+| `2`      | Configures the OpenSSL environment for **TLS handshake benchmarking** by uncommenting PQC-related configuration lines.                                                                    |
+
+
+
+
+
 
 ## Liboqs Automated Testing Scripts 
 The Liboqs PQC performance testing utilises a single bash script to conduct the automated benchmarking. This script performs CPU speed testing and memory usage profiling for supported KEM and digital signature algorithms. It is designed to be run interactively, prompting the user for test parameters such as the machine ID and number of test iterations.

--- a/docs/performance-metrics-guide.md
+++ b/docs/performance-metrics-guide.md
@@ -92,7 +92,7 @@ The table below outlines where this data is stored and how it's organised in the
 | Performance Averages | Parsed    | Average results for the performance metrics across test runs.                                                                                          | Located alongside parsed CSV files in `results/liboqs/machine-X/` |
 
 ## OQS-Provider PQC TLS Performance Metrics
-The OQS-Provider TLS performance testing captures benchmarking data for PQC and Hybrid-PQC algorithms integrated into the OpenSSL 3.4.1 library. It evaluates both their performance within the TLS 1.3 handshake protocol and their cryptographic operation speed when executed directly through OpenSSL. This testing provides valuable insight into how PQC schemes perform in real-world security protocol scenarios. Additionally, TLS handshake metrics are gathered using classical digital signature algorithms and cipher suites to establish a performance baseline for comparison with PQC and Hybrid-PQC results.
+The OQS-Provider TLS performance testing captures benchmarking data for PQC and Hybrid-PQC algorithms integrated into the OpenSSL 3.5.0 library. It evaluates both their performance within the TLS 1.3 handshake protocol and their cryptographic operation speed when executed directly through OpenSSL. This testing provides valuable insight into how PQC schemes perform in real-world security protocol scenarios. Additionally, TLS handshake metrics are gathered using classical digital signature algorithms and cipher suites to establish a performance baseline for comparison with PQC and Hybrid-PQC results.
 
 As part of the automated TLS testing, two categories of evaluations are conducted:
 
@@ -164,6 +164,6 @@ When running the OQS-Provider TLS benchmarking script (`full-oqs-provider-test.s
 - [OQS-Provider Webpage](https://openquantumsafe.org/applications/tls.html#oqs-openssl-provider)
 - [OQS-Provider GitHub Page](https://github.com/open-quantum-safe/oqs-provider)
 - [OQS Profiling Project](https://openquantumsafe.org/benchmarking/)
-- [OpenSSL(3.4.1) Documentation](https://docs.openssl.org/3.4/)
+- [OpenSSL(3.5.0) Documentation](https://docs.openssl.org/3.5/)
 - [OQS Benchmarking Webpage](https://openquantumsafe.org/benchmarking/)
 - [OQS Profiling Project](https://openquantumsafe.org/benchmarking/)

--- a/docs/supported-algorithms.md
+++ b/docs/supported-algorithms.md
@@ -30,6 +30,8 @@ When benchmarking tests are carried out using this tool, **ML-DSA** and **SLH-DS
 
 Furthermore, although **SLH-DSA** is supported at the provider level in OpenSSL 3.5.0 and can be used to generate and verify X.509 certificates, it is not yet supported for use in TLS handshakes (e.g., via `s_server`, `s_client`, or automated TLS benchmarking). This limitation is due to the current lack of integration into the OpenSSL TLS (libssl) layer. The integration of SLH-DSA into TLS 1.3 is in progress and being tracked by the [IETF draft](https://datatracker.ietf.org/doc/html/draft-reddy-tls-slhdsa-01). To allow continued evaluation of stateless hash-based signature schemes in TLS contexts, the implementation of SPHINCS+ available in the OQS-Provider library will be used ain place of SLH-DSA. This will remain the case in this project until full support of the SLH-DSA is available in OpenSSL.
 
+Finally, although the algorithm **X448MLKEM1024** is listed as a supported key encapsulation mechanism at the provider level and functions correctly with OpenSSL tools such as `speed`, **it is not registered as a supported TLS group for use with s_client, s_server, or the SSL_CONF_cmd interface.** Until it is fully supported as a TLS group, this hybrid scheme will be excluded from automated TLS handshake testing, though it remains available for cryptographic benchmarking and other non-TLS use cases.
+
 Hopefully, support will be added for the schemes to be tested using this tool in futures updates in both this project and the OpenSSL project.
 
 In addition to the natively supported PQC algorithms, the project provides TLS benchmarking for classical schemes to provide meaningful performance baselines against PQC schemes. These include:

--- a/docs/supported-algorithms.md
+++ b/docs/supported-algorithms.md
@@ -1,0 +1,56 @@
+# Supported PQC Algorithms
+
+## Support Overview
+This document outlines the algorithms supported in this project based on the upstream cryptographic dependencies (liboqs, OQS-Provider, and OpenSSL). It also details exclusions and the rationale behind them.
+
+The PQC-Evaluation-Tools project provides support for all the PQC algorithms provided by its various dependency libraries. However, there are some exceptions to this which are detailed in the following subsections. For detailed information of the algorithms this project supports, please refer to the following dependency library documentation:
+
+- [Liboqs Supported Algorithms](https://github.com/open-quantum-safe/liboqs?tab=readme-ov-file#supported-algorithms)
+- [OpenSSL Supported PQC Algorithms](https://github.com/openssl/openssl/releases/tag/openssl-3.5.0)
+- [OQS-Provider Supported Algorithms](https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md)
+
+## Liboqs Algorithms
+All algorithms provided by Liboqs are supported within the project by default apart from **HQC** and its variations. This is due to the current implementation of the scheme in Liboqs containing a IND-CCA2 vulnerability which affects the security of the HQC KEM family. By default this project will not enable HQC for use in computational performance testing. However, the project does provide functionality to enable HQC should the user wish to do so.
+
+Additionally, memory profiling for **Falcon** algorithm variants is currently non-functional on **ARM** systems due to issues with the scheme and the Valgrind Massif tool. Please see the [bug report](https://github.com/open-quantum-safe/liboqs/issues/1761) for details. Testing and parsing remain fully functional for all other algorithms.
+
+For more information on enabling HQC and the issue as a whole, please refer to the following documentation:
+
+- See the [Advanced Setup Configuration Guide](../advanced-setup-configuration.md) for instructions on enabling HQC.
+- Refer to the [Disclaimer Document](../../DISCLAIMER.md) for security warnings and usage guidance.
+
+## OpenSSL Algorithms
+OpenSSL 3.5.0 now provides support for the NIST standardised PQC algorithms ML-KEM, ML-DSA, and SLH-DSA. This project provides support for integrating these implementations from OpenSSL within its automated TLS benchmarking functionality. However, some limitations do exist for their performance testing when using the OpenSSL `speed` utility.
+
+When benchmarking tests are carried out using this tool, **ML-DSA** and **SLH-DSA** cannot be tested, as the `speed` utility does not support these algorithms currently. This is shown from the following output when attempting to use the schemes with the tool:
+
+```
+407C0B051C750000:error:03000096:digital envelope routines:evp_pkey_signature_init:operation not supported for this keytype:crypto/evp/signature.c:722:
+```
+
+Hopefully, support will be added for the schemes to be tested using this tool in futures updates in both this project and the OpenSSL project.
+
+In addition to the natively supported PQC algorithms, the project provides TLS benchmarking for classical schemes to provide meaningful performance baselines against PQC schemes. These include:
+
+- RSA-2048
+- RSA-3072
+- RSA-4096
+- prime256v1
+- secp384r1
+- secp521r1
+
+## OQS-Provider Algorithms
+The majority of algorithms provided by the OQS-Provider are supported by this project for use in automated TLS and cryptographic benchmarking. However, a small number of algorithms are explicitly excluded due to known incompatibilities with TLS 1.3 or unsupported behavior in OpenSSL's benchmarking tools.
+
+The following signature algorithms are excluded from the automated TLS benchmarking due to incompatibilities with [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446), which defines TLS 1.3. These schemes do not meet the specification's requirements for digital signatures in TLS handshakes:
+
+- **UOV-based schemes** (e.g., `OV_Is`, `OV_III`, and their hybrid variants)
+- **CROSSrsdp256small**
+
+These algorithms remain available within the OQS-Provider and may be usable in non-TLS applications, but they are automatically filtered out from handshake-based tests and benchmarking in this project.
+
+Furthermore, with the addition of native PQC support in OpenSSL 3.5.0, the OQS-Provider **automatically disables its own implementations** of overlapping schemes (e.g., ML-KEM, ML-DSA, SLH-DSA) when compiled against this version.
+
+For further information on this, please refer to the following OQS-Provider documentation:
+
+- [OQS-Provider Notice](https://github.com/open-quantum-safe/oqs-provider?tab=readme-ov-file#35-and-greater)

--- a/docs/supported-algorithms.md
+++ b/docs/supported-algorithms.md
@@ -1,6 +1,6 @@
-# Supported PQC Algorithms
+# Supported PQC Algorithms <!-- omit from toc -->
 
-## Support Overview
+## Support Overview <!-- omit from toc -->
 This document outlines the algorithms supported in this project based on the upstream cryptographic dependencies (liboqs, OQS-Provider, and OpenSSL). It also details exclusions and the rationale behind them.
 
 The PQC-Evaluation-Tools project provides support for all the PQC algorithms provided by its various dependency libraries. However, there are some exceptions to this which are detailed in the following subsections. For detailed information of the algorithms this project supports, please refer to the following dependency library documentation:
@@ -9,42 +9,201 @@ The PQC-Evaluation-Tools project provides support for all the PQC algorithms pro
 - [OpenSSL Supported PQC Algorithms](https://github.com/openssl/openssl/releases/tag/openssl-3.5.0)
 - [OQS-Provider Supported Algorithms](https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md)
 
+## Contents <!-- omit from toc -->
+- [Liboqs Algorithms](#liboqs-algorithms)
+  - [Algorithm Support Summary](#algorithm-support-summary)
+  - [Supported KEM Algorithms](#supported-kem-algorithms)
+  - [Supported Digital Signature Algorithms](#supported-digital-signature-algorithms)
+- [OpenSSL Algorithms](#openssl-algorithms)
+  - [Algorithm Support Summary](#algorithm-support-summary-1)
+  - [Supported KEM Algorithms](#supported-kem-algorithms-1)
+  - [Supported Digital Signature Algorithms](#supported-digital-signature-algorithms-1)
+  - [Supported Classical Algorithms](#supported-classical-algorithms)
+- [OQS-Provider Algorithms - NEEDS UPDATED ONCE UOV PATCH DONE](#oqs-provider-algorithms---needs-updated-once-uov-patch-done)
+  - [Algorithm Support Summary](#algorithm-support-summary-2)
+  - [Supported KEM Algorithms](#supported-kem-algorithms-2)
+  - [Supported Digital Signature Algorithms](#supported-digital-signature-algorithms-2)
+
 ## Liboqs Algorithms
-All algorithms provided by Liboqs are supported within the project by default apart from **HQC** and its variations. This is due to the current implementation of the scheme in Liboqs containing a IND-CCA2 vulnerability which affects the security of the HQC KEM family. By default this project will not enable HQC for use in computational performance testing. However, the project does provide functionality to enable HQC should the user wish to do so.
 
-Additionally, memory profiling for **Falcon** algorithm variants is currently non-functional on **ARM** systems due to issues with the scheme and the Valgrind Massif tool. Please see the [bug report](https://github.com/open-quantum-safe/liboqs/issues/1761) for details. Testing and parsing remain fully functional for all other algorithms.
+### Algorithm Support Summary
+The PQC-Evaluation-Tools project supports all key encapsulation mechanisms (KEMs) and digital signature algorithms provided by liboqs, with two notable exceptions:
 
-For more information on enabling HQC and the issue as a whole, please refer to the following documentation:
+- **HQC** and its variants are excluded by default due to a known IND-CCA2 vulnerability in the current implementation of Liboqs. As a result, HQC is not enabled for performance benchmarking unless explicitly configured by the user.
+
+- **Falcon** digital signature variants are not compatible with **memory profiling on ARM systems** due to issues between the scheme’s structure and the Valgrind Massif tool. This does not affect general functional testing or result parsing, which remain fully supported across all platforms.
+
+These exceptions are reflected in the support tables below. For users who wish to enable HQC despite the security risk, configuration instructions are provided in the advanced setup guide.
+
+For additional information, please refer to the following documentation:
 
 - See the [Advanced Setup Configuration Guide](../advanced-setup-configuration.md) for instructions on enabling HQC.
 - Refer to the [Disclaimer Document](../../DISCLAIMER.md) for security warnings and usage guidance.
 
+### Supported KEM Algorithms
+
+| **Algorithm Name**        | **NIST Security Level** | **Requires Enabling (*)** |
+|---------------------------|-------------------------|---------------------------|
+| BIKE-L1                   | 1                       |                           |
+| BIKE-L3                   | 3                       |                           |
+| BIKE-L5                   | 5                       |                           |
+| Classic-McEliece-348864   | 1                       |                           |
+| Classic-McEliece-348864f  | 1                       |                           |
+| Classic-McEliece-460896   | 3                       |                           |
+| Classic-McEliece-460896f  | 3                       |                           |
+| Classic-McEliece-6688128  | 5                       |                           |
+| Classic-McEliece-6688128f | 5                       |                           |
+| Classic-McEliece-6960119  | 5                       |                           |
+| Classic-McEliece-6960119f | 5                       |                           |
+| Classic-McEliece-8192128  | 5                       |                           |
+| Classic-McEliece-8192128f | 5                       |                           |
+| Kyber512                  | 1                       |                           |
+| Kyber768                  | 3                       |                           |
+| Kyber1024                 | 5                       |                           |
+| ML-KEM-512                | 1                       |                           |
+| ML-KEM-768                | 3                       |                           |
+| ML-KEM-1024               | 5                       |                           |
+| sntrup761                 | 2                       |                           |
+| FrodoKEM-640-AES          | 1                       |                           |
+| FrodoKEM-640-SHAKE        | 1                       |                           |
+| FrodoKEM-976-AES          | 3                       |                           |
+| FrodoKEM-976-SHAKE        | 3                       |                           |
+| FrodoKEM-1344-AES         | 5                       |                           |
+| FrodoKEM-1344-SHAKE       | 5                       |                           |
+| HQC-128                   | 1                       |             *             |
+| HQC-192                   | 3                       |             *             |
+| HQC-256                   | 5                       |             *             |
+
+### Supported Digital Signature Algorithms
+| **Algorithm Name**         | **NIST Security Level** | **Requires Enabling (*)** |
+|----------------------------|-------------------------|---------------------------|
+| Dilithium2                 | 2                       |                           |
+| Dilithium3                 | 3                       |                           |
+| Dilithium5                 | 5                       |                           |
+| ML-DSA-44                  | 2                       |                           |
+| ML-DSA-65                  | 3                       |                           |
+| ML-DSA-87                  | 5                       |                           |
+| Falcon-512                 | 1                       |                           |
+| Falcon-1024                | 5                       |                           |
+| Falcon-padded-512          | 1                       |                           |
+| Falcon-padded-1024         | 5                       |                           |
+| SPHINCS+-SHA2-128f-simple  | 1                       |                           |
+| SPHINCS+-SHA2-128s-simple  | 1                       |                           |
+| SPHINCS+-SHA2-192f-simple  | 3                       |                           |
+| SPHINCS+-SHA2-192s-simple  | 3                       |                           |
+| SPHINCS+-SHA2-256f-simple  | 5                       |                           |
+| SPHINCS+-SHA2-256s-simple  | 5                       |                           |
+| SPHINCS+-SHAKE-128f-simple | 1                       |                           |
+| SPHINCS+-SHAKE-128s-simple | 1                       |                           |
+| SPHINCS+-SHAKE-192f-simple | 3                       |                           |
+| SPHINCS+-SHAKE-192s-simple | 3                       |                           |
+| SPHINCS+-SHAKE-256f-simple | 5                       |                           |
+| SPHINCS+-SHAKE-256s-simple | 5                       |                           |
+| MAYO-1                     | 1                       |                           |
+| MAYO-2                     | 1                       |                           |
+| MAYO-3                     | 3                       |                           |
+| MAYO-5                     | 5                       |                           |
+| cross-rsdp-128-balanced    | 1                       |                           |
+| cross-rsdp-128-fast        | 1                       |                           |
+| cross-rsdp-128-small       | 1                       |                           |
+| cross-rsdp-192-balanced    | 3                       |                           |
+| cross-rsdp-192-fast        | 3                       |                           |
+| cross-rsdp-192-small       | 3                       |                           |
+| cross-rsdp-256-balanced    | 5                       |                           |
+| cross-rsdp-256-fast        | 5                       |                           |
+| cross-rsdp-256-small       | 5                       |                           |
+| cross-rsdpg-128-balanced   | 1                       |                           |
+| cross-rsdpg-128-fast       | 1                       |                           |
+| cross-rsdpg-128-small      | 1                       |                           |
+| cross-rsdpg-192-balanced   | 3                       |                           |
+| cross-rsdpg-192-fast       | 3                       |                           |
+| cross-rsdpg-192-small      | 3                       |                           |
+| cross-rsdpg-256-balanced   | 5                       |                           |
+| cross-rsdpg-256-fast       | 5                       |                           |
+| cross-rsdpg-256-small      | 5                       |                           |
+| OV-Is                      | 1                       |                           |
+| OV-Ip                      | 1                       |                           |
+| OV-III                     | 3                       |                           |
+| OV-V                       | 5                       |                           |
+| OV-Is-pkc                  | 1                       |                           |
+| OV-Ip-pkc                  | 1                       |                           |
+| OV-III-pkc                 | 3                       |                           |
+| OV-V-pkc                   | 5                       |                           |
+| OV-Is-pkc-skc              | 1                       |                           |
+| OV-Ip-pkc-skc              | 1                       |                           |
+| OV-III-pkc-skc             | 3                       |                           |
+| OV-V-pkc-skc               | 5                       |                           |
+| SNOVA_24_5_4               | 1                       |                           |
+| SNOVA_24_5_4_SHAKE         | 1                       |                           |
+| SNOVA_24_5_4_esk           | 1                       |                           |
+| SNOVA_24_5_4_SHAKE_esk     | 1                       |                           |
+| SNOVA_37_17_2              | 1                       |                           |
+| SNOVA_25_8_3               | 1                       |                           |
+| SNOVA_56_25_2              | 3                       |                           |
+| SNOVA_49_11_3              | 3                       |                           |
+| SNOVA_37_8_4               | 3                       |                           |
+| SNOVA_24_5_5               | 3                       |                           |
+| SNOVA_60_10_4              | 5                       |                           |
+| SNOVA_29_6_5               | 5                       |                           |
+
 ## OpenSSL Algorithms
-OpenSSL 3.5.0 now provides support for the NIST standardised PQC algorithms ML-KEM, ML-DSA, and SLH-DSA. This project provides support for integrating these implementations from OpenSSL within its automated TLS benchmarking functionality. However, some limitations do exist for their performance testing when using the OpenSSL `speed` utility.
 
-When benchmarking tests are carried out using this tool, **ML-DSA** and **SLH-DSA** cannot be tested, as the `speed` utility does not support these algorithms currently. This is shown from the following output when attempting to use the schemes with the tool:
+### Algorithm Support Summary
+OpenSSL 3.5.0 introduces native support for the NIST-standardized post-quantum cryptographic algorithms **ML-KEM**, **ML-DSA**, and **SLH-DSA**. This project integrates these algorithms for TLS benchmarking where possible. However, some limitations affect their usage in performance testing and handshake scenarios:
 
-```
-407C0B051C750000:error:03000096:digital envelope routines:evp_pkey_signature_init:operation not supported for this keytype:crypto/evp/signature.c:722:
-```
+#### Known Limitations
 
-Furthermore, although **SLH-DSA** is supported at the provider level in OpenSSL 3.5.0 and can be used to generate and verify X.509 certificates, it is not yet supported for use in TLS handshakes (e.g., via `s_server`, `s_client`, or automated TLS benchmarking). This limitation is due to the current lack of integration into the OpenSSL TLS (libssl) layer. The integration of SLH-DSA into TLS 1.3 is in progress and being tracked by the [IETF draft](https://datatracker.ietf.org/doc/html/draft-reddy-tls-slhdsa-01). To allow continued evaluation of stateless hash-based signature schemes in TLS contexts, the implementation of SPHINCS+ available in the OQS-Provider library will be used ain place of SLH-DSA. This will remain the case in this project until full support of the SLH-DSA is available in OpenSSL.
+- **ML-DSA** and **SLH-DSA** are currently not supported by the OpenSSL `speed` utility, making them unavailable for cryptographic performance benchmarking.
 
-Finally, although the algorithm **X448MLKEM1024** is listed as a supported key encapsulation mechanism at the provider level and functions correctly with OpenSSL tools such as `speed`, **it is not registered as a supported TLS group for use with s_client, s_server, or the SSL_CONF_cmd interface.** Until it is fully supported as a TLS group, this hybrid scheme will be excluded from automated TLS handshake testing, though it remains available for cryptographic benchmarking and other non-TLS use cases.
+- **SLH-DSA** is supported at the provider level (e.g., for generating X.509 certificates) but is not yet integrated into the OpenSSL TLS stack (`s_client`, `s_server`, or `speed`). Its future integration into TLS 1.3 is being tracked via this [IETF draft](https://datatracker.ietf.org/doc/html/draft-reddy-tls-slhdsa-01). Until then, SPHINCS+ from the OQS-Provider will be used as a placeholder for stateless hash-based signatures in TLS tests.
+  
+- The **X448MLKEM1024** Hybrid-PQC KEM is implemented and supported by OpenSSL's `speed` tool but not registered as a TLS group. It is excluded from handshake testing, though it remains available for standalone benchmarking and non-TLS evaluations.
 
-Hopefully, support will be added for the schemes to be tested using this tool in futures updates in both this project and the OpenSSL project.
 
-In addition to the natively supported PQC algorithms, the project provides TLS benchmarking for classical schemes to provide meaningful performance baselines against PQC schemes. These include:
+#### Classical Algorithm Benchmarks
+To provide performance baselines for comparison, classical algorithms are also included in TLS benchmarking:
 
-- RSA-2048
-- RSA-3072
-- RSA-4096
-- prime256v1
-- secp384r1
-- secp521r1
+- RSA-2048, RSA-3072, RSA-4096
+- prime256v1, secp384r1, secp521r1
 
-## OQS-Provider Algorithms
-The majority of algorithms provided by the OQS-Provider are supported by this project for use in automated TLS and cryptographic benchmarking. However, a small number of algorithms are explicitly excluded due to known incompatibilities with TLS 1.3 or unsupported behavior in OpenSSL's benchmarking tools.
+These schemes help assess the overhead and feasibility of PQC adoption in real-world contexts.
+
+### Supported KEM Algorithms
+
+| **Algorithm Name** | **Hybrid Algorithm (*)** | **TLS Handshake Test Support (*)** | **OpenSSL Speed Test Support (*)** |
+|--------------------|--------------------------|------------------------------------|------------------------------------|
+| MLKEM512           |                          |                  *                 |                  *                 |
+| MLKEM768           |                          |                  *                 |                                    |
+| MLKEM1024          |                          |                  *                 |                  *                 |
+| X25519MLKEM768     |             *            |                  *                 |                  *                 |
+| X448MLKEM1024      |             *            |                                    |                  *                 |
+| SecP256r1MLKEM768  |             *            |                  *                 |                  *                 |
+| SecP384r1MLKEM1024 |             *            |                  *                 |                  *                 |
+
+### Supported Digital Signature Algorithms
+
+| **Algorithm Name** | **Hybrid Algorithm (*)** | **TLS Handshake Test Support (*)** | **OpenSSL Speed Test Support (*)** |
+|--------------------|--------------------------|------------------------------------|------------------------------------|
+| MLDSA44            |                          |                  *                 |                                    |
+| MLDSA65            |                          |                  *                 |                                    |
+| MLDSA87            |                          |                  *                 |                                    |
+
+### Supported Classical Algorithms
+
+| **Algorithm Name** | **TLS Handshake Test Support (*)** | **OpenSSL Speed Test Support (*)** |
+|--------------------|------------------------------------|------------------------------------|
+| RSA-2048           |                  *                 |                  *                 |
+| RSA-3072           |                  *                 |                  *                 |
+| RSA-4096           |                  *                 |                  *                 |
+| prime256v1         |                  *                 |                  *                 |
+| secp384r1          |                  *                 |                  *                 |
+| secp521r1          |                  *                 |                  *                 |
+
+## OQS-Provider Algorithms - NEEDS UPDATED ONCE UOV PATCH DONE
+
+### Algorithm Support Summary
+
+The majority of algorithms provided by the OQS-Provider are supported by this project for use in automated TLS and cryptographic benchmarking. However, a small number of algorithms are explicitly excluded due to known incompatibilities with TLS 1.3 or unsupported behaviours in OpenSSL's benchmarking tools.
 
 The following signature algorithms are excluded from the automated TLS benchmarking due to incompatibilities with [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446), which defines TLS 1.3. These schemes do not meet the specification's requirements for digital signatures in TLS handshakes:
 
@@ -58,3 +217,135 @@ Furthermore, with the addition of native PQC support in OpenSSL 3.5.0, the OQS-P
 For further information on this, please refer to the following OQS-Provider documentation:
 
 - [OQS-Provider Notice](https://github.com/open-quantum-safe/oqs-provider?tab=readme-ov-file#35-and-greater)
+
+
+### Supported KEM Algorithms
+
+| **Algorithm Name**   | **Hybrid Algorithm (*)** | **TLS Handshake Test Support (*)** | **OpenSSL Speed Test Support (*)** | **Requires Enabling (*)** |
+|----------------------|--------------------------|------------------------------------|------------------------------------|---------------------------|
+| frodo640aes          |                          |                  *                 |                  *                 |                           |
+| frodo640shake        |                          |                  *                 |                  *                 |                           |
+| frodo976aes          |                          |                  *                 |                  *                 |                           |
+| frodo976shake        |                          |                  *                 |                  *                 |                           |
+| frodo1344aes         |                          |                  *                 |                  *                 |                           |
+| frodo1344shake       |                          |                  *                 |                  *                 |                           |
+| p256_frodo640aes     |             *            |                  *                 |                  *                 |                           |
+| x25519_frodo640aes   |             *            |                  *                 |                  *                 |                           |
+| p256_frodo640shake   |             *            |                  *                 |                  *                 |                           |
+| x25519_frodo640shake |             *            |                  *                 |                  *                 |                           |
+| p384_frodo976aes     |             *            |                  *                 |                  *                 |                           |
+| x448_frodo976aes     |             *            |                  *                 |                  *                 |                           |
+| p384_frodo976shake   |             *            |                  *                 |                  *                 |                           |
+| x448_frodo976shake   |             *            |                  *                 |                  *                 |                           |
+| p521_frodo1344aes    |             *            |                  *                 |                  *                 |                           |
+| p521_frodo1344shake  |             *            |                  *                 |                  *                 |                           |
+| bikel1               |                          |                  *                 |                  *                 |                           |
+| bikel3               |                          |                  *                 |                  *                 |                           |
+| bikel5               |                          |                  *                 |                  *                 |                           |
+| p256_bikel1          |             *            |                  *                 |                  *                 |                           |
+| x25519_bikel1        |             *            |                  *                 |                  *                 |                           |
+| p384_bikel3          |             *            |                  *                 |                  *                 |                           |
+| x448_bikel3          |             *            |                  *                 |                  *                 |                           |
+| p521_bikel5          |             *            |                  *                 |                  *                 |                           |
+| p256_mlkem512        |             *            |                  *                 |                  *                 |                           |
+| x25519_mlkem512      |             *            |                  *                 |                  *                 |                           |
+| p384_mlkem768        |             *            |                  *                 |                  *                 |                           |
+| x448_mlkem768        |             *            |                  *                 |                  *                 |                           |
+| p521_mlkem1024       |             *            |                  *                 |                  *                 |                           |
+
+
+### Supported Digital Signature Algorithms
+
+| **Algorithm Name**             | **Hybrid Algorithm (*)** | **TLS Handshake Test Support (*)** | **OpenSSL Speed Test Support (*)** | **Requires Enabling (*)** |
+|--------------------------------|--------------------------|------------------------------------|------------------------------------|---------------------------|
+| falcon512                      |                          |                  *                 |                  *                 |                           |
+| falconpadded512                |                          |                  *                 |                  *                 |                           |
+| falcon1024                     |                          |                  *                 |                  *                 |                           |
+| falconpadded1024               |                          |                  *                 |                  *                 |                           |
+| p256_falcon512                 |             *            |                  *                 |                  *                 |                           |
+| rsa3072_falcon512              |             *            |                  *                 |                  *                 |                           |
+| p256_falconpadded512           |             *            |                  *                 |                  *                 |                           |
+| rsa3072_falconpadded512        |             *            |                  *                 |                  *                 |                           |
+| p521_falcon1024                |             *            |                  *                 |                  *                 |                           |
+| p521_falconpadded1024          |             *            |                  *                 |                  *                 |                           |
+| sphincssha2128fsimple          |                          |                  *                 |                  *                 |                           |
+| sphincssha2128ssimple          |                          |                  *                 |                  *                 |                           |
+| sphincssha2192fsimple          |                          |                  *                 |                  *                 |                           |
+| sphincssha2192ssimple          |                          |                  *                 |                  *                 |             *             |
+| sphincssha2256fsimple          |                          |                  *                 |                  *                 |             *             |
+| sphincssha2256ssimple          |                          |                  *                 |                  *                 |             *             |
+| sphincsshake128fsimple         |                          |                  *                 |                  *                 |                           |
+| sphincsshake128ssimple         |                          |                  *                 |                  *                 |             *             |
+| sphincsshake192fsimple         |                          |                  *                 |                  *                 |             *             |
+| sphincsshake192ssimple         |                          |                  *                 |                  *                 |             *             |
+| sphincsshake256fsimple         |                          |                  *                 |                  *                 |             *             |
+| sphincsshake256ssimple         |                          |                  *                 |                  *                 |             *             |
+| p256_sphincssha2128fsimple     |             *            |                  *                 |                  *                 |                           |
+| rsa3072_sphincssha2128fsimple  |             *            |                  *                 |                  *                 |                           |
+| p256_sphincssha2128ssimple     |             *            |                  *                 |                  *                 |                           |
+| rsa3072_sphincssha2128ssimple  |             *            |                  *                 |                  *                 |                           |
+| p384_sphincssha2192fsimple     |             *            |                  *                 |                  *                 |                           |
+| p384_sphincssha2192ssimple     |             *            |                  *                 |                  *                 |                           |
+| p521_sphincssha2256fsimple     |             *            |                  *                 |                  *                 |             *             |
+| p521_sphincssha2256ssimple     |             *            |                  *                 |                  *                 |             *             |
+| p256_sphincsshake128fsimple    |             *            |                  *                 |                  *                 |                           |
+| rsa3072_sphincsshake128fsimple |             *            |                  *                 |                  *                 |                           |
+| p256_sphincsshake128ssimple    |             *            |                  *                 |                  *                 |             *             |
+| rsa3072_sphincsshake128ssimple |             *            |                  *                 |                  *                 |             *             |
+| p384_sphincsshake192fsimple    |             *            |                  *                 |                  *                 |             *             |
+| p384_sphincsshake192ssimple    |             *            |                  *                 |                  *                 |             *             |
+| p521_sphincsshake256fsimple    |             *            |                  *                 |                  *                 |             *             |
+| p521_sphincsshake256ssimple    |             *            |                  *                 |                  *                 |             *             |
+| mayo1                          |                          |                  *                 |                  *                 |                           |
+| mayo2                          |                          |                  *                 |                  *                 |                           |
+| mayo3                          |                          |                  *                 |                  *                 |                           |
+| mayo5                          |                          |                  *                 |                  *                 |                           |
+| p256_mayo1                     |             *            |                  *                 |                  *                 |                           |
+| p256_mayo2                     |             *            |                  *                 |                  *                 |                           |
+| p384_mayo3                     |             *            |                  *                 |                  *                 |                           |
+| p521_mayo5                     |             *            |                  *                 |                  *                 |                           |
+| CROSSrsdp128balanced           |                          |                  *                 |                  *                 |                           |
+| CROSSrsdp128fast               |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdp128small              |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdp192balanced           |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdp192fast               |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdp192small              |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdp256small              |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg128balanced          |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg128fast              |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg128small             |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg192balanced          |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg192fast              |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg192small             |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg256balanced          |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg256fast              |                          |                  *                 |                  *                 |             *             |
+| CROSSrsdpg256small             |                          |                                    |                  *                 |             *             |
+| OV_Is                          |                          |                                    |                  *                 |             *             |
+| OV_Ip                          |                          |                                    |                  *                 |             *             |
+| OV_III                         |                          |                                    |                  *                 |             *             |
+| OV_V                           |                          |                                    |                  *                 |             *             |
+| OV_Is_pkc                      |                          |                                    |                  *                 |                           |
+| OV_Ip_pkc                      |                          |                  *                 |                  *                 |                           |
+| OV_III_pkc                     |                          |                                    |                  *                 |             *             |
+| OV_V_pkc                       |                          |                                    |                  *                 |             *             |
+| OV_Is_pkc_skc                  |                          |                                    |                  *                 |                           |
+| OV_Ip_pkc_skc                  |                          |                  *                 |                  *                 |                           |
+| OV_III_pkc_skc                 |                          |                                    |                  *                 |             *             |
+| OV_V_pkc_skc                   |                          |                                    |                  *                 |             *             |
+| p256_OV_Is                     |             *            |                                    |                  *                 |             *             |
+| p256_OV_Ip                     |             *            |                                    |                  *                 |             *             |
+| p384_OV_III                    |             *            |                                    |                  *                 |             *             |
+| p521_OV_V                      |             *            |                                    |                  *                 |             *             |
+| p256_OV_Is_pkc                 |             *            |                                    |                  *                 |                           |
+| p256_OV_Ip_pkc                 |             *            |                  *                 |                  *                 |                           |
+| p384_OV_III_pkc                |             *            |                                    |                  *                 |             *             |
+| p521_OV_V_pkc                  |             *            |                                    |                  *                 |             *             |
+| p256_OV_Is_pkc_skc             |             *            |                                    |                  *                 |                           |
+| p256_OV_Ip_pkc_skc             |             *            |                  *                 |                  *                 |                           |
+| p384_OV_III_pkc_skc            |             *            |                                    |                  *                 |             *             |
+| p521_OV_V_pkc_skc              |             *            |                                    |                  *                 |             *             |
+| p256_mldsa44                   |             *            |                  *                 |                  *                 |             *             |
+| rsa3072_mldsa44                |             *            |                  *                 |                  *                 |             *             |
+| p384_mldsa65                   |             *            |                  *                 |                  *                 |             *             |
+| p521_mldsa87                   |             *            |                  *                 |                  *                 |             *             |
+

--- a/docs/supported-algorithms.md
+++ b/docs/supported-algorithms.md
@@ -28,6 +28,8 @@ When benchmarking tests are carried out using this tool, **ML-DSA** and **SLH-DS
 407C0B051C750000:error:03000096:digital envelope routines:evp_pkey_signature_init:operation not supported for this keytype:crypto/evp/signature.c:722:
 ```
 
+Furthermore, although **SLH-DSA** is supported at the provider level in OpenSSL 3.5.0 and can be used to generate and verify X.509 certificates, it is not yet supported for use in TLS handshakes (e.g., via `s_server`, `s_client`, or automated TLS benchmarking). This limitation is due to the current lack of integration into the OpenSSL TLS (libssl) layer. The integration of SLH-DSA into TLS 1.3 is in progress and being tracked by the [IETF draft](https://datatracker.ietf.org/doc/html/draft-reddy-tls-slhdsa-01). To allow continued evaluation of stateless hash-based signature schemes in TLS contexts, the implementation of SPHINCS+ available in the OQS-Provider library will be used ain place of SLH-DSA. This will remain the case in this project until full support of the SLH-DSA is available in OpenSSL.
+
 Hopefully, support will be added for the schemes to be tested using this tool in futures updates in both this project and the OpenSSL project.
 
 In addition to the natively supported PQC algorithms, the project provides TLS benchmarking for classical schemes to provide meaningful performance baselines against PQC schemes. These include:

--- a/docs/testing-tools-usage/oqsprovider-performance-testing.md
+++ b/docs/testing-tools-usage/oqsprovider-performance-testing.md
@@ -1,19 +1,13 @@
 # Automated PQC TLS Performance Benchmarking Tool Usage Guide <!-- omit from toc -->
 
 ## Overview <!-- omit from toc -->
-This tool provides automated benchmarking for PQC-enabled TLS 1.3 handshakes and cryptographic operation performance in OpenSSL 3.4.1 using the OQS-Provider library. It tests TLS handshakes with various combinations of Post-Quantum Cryptography (PQC) and Hybrid-PQC cipher suites and measures the performance of these algorithms when integrated into OpenSSL. In addition to PQC-focused benchmarks, the tool also evaluates classic cryptographic algorithms, which can serve as a baseline for comparing PQC-based results. Testing can be conducted on a single machine (localhost) or across two networked machines, using a physical or virtual connection.
+This tool provides automated benchmarking for PQC-enabled TLS 1.3 handshakes and cryptographic operation performance in OpenSSL 3.5.0 using the OQS-Provider library. It tests TLS handshakes with various combinations of Post-Quantum Cryptography (PQC) and Hybrid-PQC cipher suites and measures the performance of these algorithms when integrated into OpenSSL. In addition to PQC-focused benchmarks, the tool also evaluates classic cryptographic algorithms, which can serve as a baseline for comparing PQC-based results. Testing can be conducted on a single machine (localhost) or across two networked machines, using a physical or virtual connection.
 
 The relevant PQC TLS Performance testing scripts can be found in the `scripts/test-scripts` directory from the project's root.
 
-**Note:** The following signature algorithms are excluded from the automated TLS benchmarking due to known incompatibilities with [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446):
-
-- UOV-based schemes (e.g., OV_Is, OV_III, and their hybrid variants)
-- CROSSrsdp256small
-
-These algorithms remain available for computational benchmarking using the Liboqs tools.
-
 ### Contents <!-- omit from toc -->
 - [Supported Hardware](#supported-hardware)
+- [Supported PQC Algorithms](#supported-pqc-algorithms)
 - [Preparing the Testing Environment](#preparing-the-testing-environment)
   - [Control Ports and Firewall Setup for Testing](#control-ports-and-firewall-setup-for-testing)
   - [Generating Required Certificates and Private Keys](#generating-required-certificates-and-private-keys)
@@ -33,6 +27,13 @@ The automated testing tool is currently only supported on the following devices:
 
 - x86 Linux Machines using a Debian-based operating system
 - ARM Linux devices using a 64-bit Debian based Operating System
+
+## Supported PQC Algorithms
+Whilst this project provides support for all PQC algorithms included in its dependency libraries for TLS testing, due to various incompatibles and dependency limitations, there a several PQC algorithms which are excluded. Whilst the number of algorithms not included are a small amount, it is important to consider this limitation when using the tool.
+
+Additional information on the excluded algorithms can be found in the OpenSSL and OQS-Provider subsections in the following project documentation:
+
+[Supported Algorithms](../supported-algorithms.md)
 
 ## Preparing the Testing Environment
 Before running any tests, it is crucial to ensure the necessary setup steps for your planned testing environment (single-machine/two-machine configuration) have been performed. This includes allowing required ports through your firewall and generating test server certificates and private-keys.
@@ -180,4 +181,4 @@ If the default control signalling timing behaviour is unsuitable for your testin
 - [Latest OQS-Provider Release Notes](https://github.com/open-quantum-safe/oqs-provider/blob/main/RELEASE.md)
 - [OQS Benchmarking Webpage](https://openquantumsafe.org/benchmarking/)
 - [OQS Profiling Project](https://openquantumsafe.org/benchmarking/)
-- [OpenSSL(3.4.1) Documentation](https://docs.openssl.org/3.4/)
+- [OpenSSL(3.5.0) Documentation](https://docs.openssl.org/3.5/)

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -874,11 +874,6 @@ function run_tests() {
     # Call the TLS handshake test script based on the machine type selected
     if [ $machine_type == "Server" ]; then
 
-        # Output the current task to the terminal
-        echo -e "\n####################################"
-        echo "Performing TLS Handshake Tests"
-        echo -e "####################################\n"
-
         # Export the client IP to the environment
         export CLIENT_IP="$machine_ip"
 
@@ -896,12 +891,7 @@ function run_tests() {
     
         # Export the server IP to the environment
         export SERVER_IP="$machine_ip"
-
-        # Output the current task to the terminal
-        echo -e "\n####################################"
-        echo "Performing TLS Handshake Tests"
-        echo "####################################"
-
+        
         # Call the server machine test script
         $test_scripts_path/oqsprovider-test-client.sh
         exit_code=$?
@@ -912,11 +902,6 @@ function run_tests() {
             exit 1
         fi
 
-        # Output the current task to the terminal
-        echo -e "\n##########################"
-        echo "Performing TLS Speed Tests"
-        echo -e "##########################"
-        
         # Call the TLS speed test script
         $test_scripts_path/oqsprovider-test-speed.sh
         exit_code=$?

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Callum Turino
 # SPDX-License-Identifier: MIT
 
-# Script for controlling the OQS-Provider TLS benchmarking suite using OpenSSL 3.4.1. It handles the configuration 
+# Script for controlling the OQS-Provider TLS benchmarking suite using OpenSSL 3.5.0. It handles the configuration 
 # of test parameters, machine role assignment, port and environment validation, and result directory setup. Based on 
 # the selected machine role, the script calls the relevant client or server benchmarking script to perform handshake 
 # and speed tests across post-quantum, classical, and hybrid-pqc algorithm modes, storing results in machine-specific 
@@ -346,7 +346,7 @@ function setup_base_env() {
     util_scripts="$root_dir/scripts/utility-scripts"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     oqs_provider_path="$libs_dir/oqs-provider"
 
     # Ensure that the OQS-Provider and OpenSSL libraries are present before proceeding

--- a/scripts/test-scripts/full-oqs-provider-test.sh
+++ b/scripts/test-scripts/full-oqs-provider-test.sh
@@ -883,8 +883,14 @@ function run_tests() {
         export CLIENT_IP="$machine_ip"
 
         # Call the server machine test script
-        $test_scripts_path/oqsprovider-test-server.sh 
-        #>> "$root_dir/server-test-output.txt" - uncomment to save output for debugging
+        $test_scripts_path/oqsprovider-test-server.sh
+        exit_code=$?
+
+        # Ensure that the server test script completed successfully
+        if [ $exit_code -ne 0 ]; then
+            echo "[ERROR] - TLS handshake test failed."
+            exit 1
+        fi
 
     else
     
@@ -894,19 +900,32 @@ function run_tests() {
         # Output the current task to the terminal
         echo -e "\n####################################"
         echo "Performing TLS Handshake Tests"
-        echo -e "####################################\n"
+        echo "####################################"
 
         # Call the server machine test script
         $test_scripts_path/oqsprovider-test-client.sh
-        #>> "$root_dir/client-test-output.txt" - uncomment to save output for debugging
+        exit_code=$?
+
+        # Ensure that the client test script completed successfully
+        if [ $exit_code -ne 0 ]; then
+            echo "[ERROR] - TLS handshake test failed."
+            exit 1
+        fi
 
         # Output the current task to the terminal
         echo -e "\n##########################"
         echo "Performing TLS Speed Tests"
-        echo -e "##########################\n"
+        echo -e "##########################"
         
         # Call the TLS speed test script
         $test_scripts_path/oqsprovider-test-speed.sh
+        exit_code=$?
+
+        # Ensure that the speed test script completed successfully
+        if [ $exit_code -ne 0 ]; then
+            echo "[ERROR] - TLS speed test failed."
+            exit 1
+        fi
     
     fi
 

--- a/scripts/test-scripts/oqsprovider-generate-keys.sh
+++ b/scripts/test-scripts/oqsprovider-generate-keys.sh
@@ -5,7 +5,7 @@
 
 # Script for generating all the server certificates and keys required for the TLS handshake benchmarking suite. 
 # It creates classic, post-quantum, and hybrid-pqc certificates by generating CA keys, certificate signing requests, 
-# and signed server certificates using OpenSSL 3.4.1. The resulting key material must be copied to the client machine #
+# and signed server certificates using OpenSSL 3.5.0. The resulting key material must be copied to the client machine #
 # unless both client and server run on the same system.
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ function setup_base_env() {
     util_scripts="$root_dir/scripts/utility-scripts"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     oqs_provider_path="$libs_dir/oqs-provider"
 
     # Ensure that the OQS-Provider and OpenSSL libraries are present before proceeding

--- a/scripts/test-scripts/oqsprovider-generate-keys.sh
+++ b/scripts/test-scripts/oqsprovider-generate-keys.sh
@@ -123,7 +123,10 @@ function classic_keygen() {
                 -nodes \
                 -subj "/CN=oqstest CA" \
                 -days 365 \
-                -config "$openssl_path/openssl.cnf"
+                -config "$openssl_path/openssl.cnf" \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Generate the server certificate signing request for the current RSA signature algorithm
             "$openssl_path/bin/openssl" req \
@@ -133,7 +136,10 @@ function classic_keygen() {
                 -out "$classic_cert_dir/$sig_name-srv.csr" \
                 -nodes \
                 -subj "/CN=oqstest server" \
-                -config "$openssl_path/openssl.cnf"
+                -config "$openssl_path/openssl.cnf" \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
             
             # Sign the server CSR with the RSA CA cert
             "$openssl_path/bin/openssl" x509 \
@@ -143,7 +149,10 @@ function classic_keygen() {
                 -CA "$classic_cert_dir/$sig_name-CA.crt" \
                 -CAkey "$classic_cert_dir/$sig_name-CA.key" \
                 -CAcreateserial \
-                -days 365
+                -days 365 \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Remove the server CSR file
             rm -f "$classic_cert_dir/$sig_name-srv.csr"
@@ -154,7 +163,10 @@ function classic_keygen() {
             "$openssl_path/bin/openssl" ecparam \
                 -name $sig \
                 -genkey \
-                -out "$classic_cert_dir/${sig_name}-CA.key"
+                -out "$classic_cert_dir/${sig_name}-CA.key" \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Generate the ECC CA certificate using the generated key
             "$openssl_path/bin/openssl" req \
@@ -165,32 +177,44 @@ function classic_keygen() {
                 -nodes \
                 -subj "/CN=oqstest CA" \
                 -days 365 \
-                -config "$openssl_path/openssl.cnf"
+                -config "$openssl_path/openssl.cnf" \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Generate the ECC server private key using the same curve
-            "$openssl_path/bin/openssl" ecparam \
+            "$openssl_path/bin/openssl" ecparam $PROV_ARGS \
                 -name $sig \
                 -genkey \
-                -out "$classic_cert_dir/${sig_name}-srv.key"
+                -out "$classic_cert_dir/${sig_name}-srv.key" \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Generate the certificate signing request for the server using the ECC private key
-            "$openssl_path/bin/openssl" req \
+            "$openssl_path/bin/openssl" req $PROV_ARGS \
                 -new \
                 -key "$classic_cert_dir/${sig_name}-srv.key" \
                 -out "$classic_cert_dir/${sig_name}-srv.csr" \
                 -nodes \
                 -subj "/CN=oqstest server" \
-                -config "$openssl_path/openssl.cnf"
+                -config "$openssl_path/openssl.cnf" \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Sign the server CSR using the ECC CA certificate and key
-            "$openssl_path/bin/openssl" x509 \
+            "$openssl_path/bin/openssl" x509 $PROV_ARGS \
                 -req \
                 -in "$classic_cert_dir/${sig_name}-srv.csr" \
                 -out "$classic_cert_dir/${sig_name}-srv.crt" \
                 -CA "$classic_cert_dir/${sig_name}-CA.crt" \
                 -CAkey "$classic_cert_dir/${sig_name}-CA.key" \
                 -CAcreateserial \
-                -days 365
+                -days 365 \
+                -provider default \
+                -provider oqsprovider \
+                -provider-path "$provider_path"
 
             # Remove the server CSR file
             rm -f "$classic_cert_dir/${sig_name}-srv.csr"
@@ -218,7 +242,10 @@ function pqc_keygen() {
             -nodes \
             -subj "/CN=oqstest $sig CA" \
             -days 365 \
-            -config "$openssl_path/openssl.cnf"
+            -config "$openssl_path/openssl.cnf" \
+            -provider default \
+            -provider oqsprovider \
+            -provider-path "$provider_path"
 
         # Generate the server certificate signing request for the current PQC signature algorithm
         "$openssl_path/bin/openssl" req \
@@ -228,11 +255,23 @@ function pqc_keygen() {
             -out "$pqc_cert_dir/$sig-srv.csr" \
             -nodes \
             -subj "/CN=oqstest $sig server" \
-            -config "$openssl_path/openssl.cnf"
+            -config "$openssl_path/openssl.cnf" \
+            -provider default \
+            -provider oqsprovider \
+            -provider-path "$provider_path"
 
         # Sign the server CSR using the PQC CA certificate and key
-        "$openssl_path/bin/openssl" x509 -req -in "$pqc_cert_dir/$sig-srv.csr" \
-            -out "$pqc_cert_dir/$sig-srv.crt" -CA "$pqc_cert_dir/$sig-CA.crt" -CAkey "$pqc_cert_dir/$sig-CA.key" -CAcreateserial -days 365
+        "$openssl_path/bin/openssl" x509 \
+            -req \
+            -in "$pqc_cert_dir/$sig-srv.csr" \
+            -out "$pqc_cert_dir/$sig-srv.crt" \
+            -CA "$pqc_cert_dir/$sig-CA.crt" \
+            -CAkey "$pqc_cert_dir/$sig-CA.key" \
+            -CAcreateserial \
+            -days 365 \
+            -provider default \
+            -provider oqsprovider \
+            -provider-path "$provider_path"
 
         # Remove the server CSR file
         rm -f "$pqc_cert_dir/$sig-srv.csr"
@@ -253,12 +292,15 @@ function hybrid_pqc_keygen() {
             -x509 \
             -new \
             -newkey $sig \
-            -keyout "$hybrid_cert_dir/$sig-CA.key" \
+            -keyout "$hybrid_cert_dir/$sig-CA.key" $PROV_ARGS \
             -out "$hybrid_cert_dir/$sig-CA.crt" \
             -nodes \
             -subj "/CN=oqstest $sig CA" \
             -days 365 \
-            -config "$openssl_path/openssl.cnf"
+            -config "$openssl_path/openssl.cnf" \
+            -provider default \
+            -provider oqsprovider \
+            -provider-path "$provider_path"
 
         # Generate the server certificate signing request for the current Hybrid-PQC signature algorithm
         "$openssl_path/bin/openssl" req \
@@ -268,7 +310,10 @@ function hybrid_pqc_keygen() {
             -out "$hybrid_cert_dir/$sig-srv.csr" \
             -nodes \
             -subj "/CN=oqstest $sig server" \
-            -config "$openssl_path/openssl.cnf"
+            -config "$openssl_path/openssl.cnf" \
+            -provider default \
+            -provider oqsprovider \
+            -provider-path "$provider_path"
 
         # Sign the server CSR using the Hybrid-PQC CA certificate and key
         "$openssl_path/bin/openssl" x509 \
@@ -277,7 +322,10 @@ function hybrid_pqc_keygen() {
             -out "$hybrid_cert_dir/$sig-srv.crt" \
             -CA "$hybrid_cert_dir/$sig-CA.crt" \
             -CAkey "$hybrid_cert_dir/$sig-CA.key" \
-            -CAcreateserial -days 365
+            -CAcreateserial -days 365 \
+            -provider default \
+            -provider oqsprovider \
+            -provider-path "$provider_path"
 
         # Remove the server CSR file
         rm -f "$hybrid_cert_dir/$sig-srv.csr"
@@ -297,7 +345,7 @@ function main() {
     setup_base_env
 
     # Modify the OpenSSL conf file to temporarily remove the default groups configuration
-    if ! "$util_scripts/configure-openssl-cnf.sh" 0; then
+    if ! "$util_scripts/configure-openssl-cnf.sh" 1; then
         echo "[ERROR] - Failed to modify OpenSSL configuration."
         exit 1
     fi
@@ -321,7 +369,7 @@ function main() {
     hybrid_pqc_keygen
 
     # Restore the OpenSSL conf file to have configuration needed for testing scripts
-    if ! "$util_scripts/configure-openssl-cnf.sh" 1; then
+    if ! "$util_scripts/configure-openssl-cnf.sh" 2; then
         echo "[ERROR] - Failed to modify OpenSSL configuration."
         exit 1
     fi

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -5,7 +5,7 @@
 
 # Client-side script for executing TLS handshake performance tests in coordination with a remote server. 
 # It evaluates all supported combinations of classic, Post-Quantum Cryptography (PQC), and Hybrid-PQC signature 
-# and KEM algorithms using OpenSSL 3.4.1 integrated with the OQS-Provider. The script performs three main test suites:
+# and KEM algorithms using OpenSSL 3.5.0 integrated with the OQS-Provider. The script performs three main test suites:
 # PQC-only, Hybrid-PQC, and Classic handshake tests. It is called by the full-oqs-provider-test.sh benchmarking 
 # controller script and uses globally defined test parameters, certificate files, and control signalling 
 # for synchronisation with the server.
@@ -50,7 +50,7 @@ function setup_base_env() {
     util_scripts="$root_dir/scripts/utility-scripts"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     provider_path="$libs_dir/oqs-provider/lib"
 
     # Declare global key storage directory paths

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -90,7 +90,7 @@ function setup_base_env() {
         echo "[ERROR] - Control sleep time env variable not set, this indicates a wider issue with the full-oqs-provider-test.sh script"
         exit 1
     fi
-
+    
 }
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -338,12 +338,13 @@ function pqc_tests() {
 
                         # Run the OpenSSL s_time process with current test parameters and grab the exit code
                         "$openssl_path/bin/openssl" s_time \
-                            -connect $SERVER_IP:$S_SERVER_PORT \
-                            -CAfile $cert_file -time $TIME_NUM  \
-                            -verify 1 \
+                            -connect "${SERVER_IP}:${S_SERVER_PORT}" \
+                            -CAfile  "$cert_file" \
+                            -time    "$TIME_NUM" \
+                            -verify  1 \
                             -provider default \
                             -provider oqsprovider \
-                            -provider-path $provider_path > $handshake_dir/$output_name
+                            -provider-path "$provider_path" > "$handshake_dir/$output_name"
                         exit_code=$?
 
                         # Check if the test was successful and retry if not
@@ -515,7 +516,7 @@ function tls_client_test_entrypoint() {
 
         # Set the test type, environment, and call the PQC tests function
         test_type=0
-        set_test_env $test_type 1
+        set_test_env $test_type 2
         pqc_tests
         echo -e "[OUTPUT] - Completed $run_num PQC TLS Handshake Tests"
 
@@ -527,7 +528,7 @@ function tls_client_test_entrypoint() {
 
         # Set the test type, environment, and call the Hybrid-PQC tests function
         test_type=1
-        set_test_env $test_type 1
+        set_test_env $test_type 2
         pqc_tests
         echo "[OUTPUT] - Completed $run_num Hybrid-PQC TLS Handshake Tests"
 
@@ -539,7 +540,7 @@ function tls_client_test_entrypoint() {
 
         # Set the test type, environment, and call the classic tests function
         test_type=2
-        set_test_env $test_type 1
+        set_test_env $test_type 2
         classic_tests
         echo "[OUTPUT] - Completed $run_num Classic TLS Handshake Tests"
 

--- a/scripts/test-scripts/oqsprovider-test-client.sh
+++ b/scripts/test-scripts/oqsprovider-test-client.sh
@@ -487,7 +487,7 @@ function tls_client_test_entrypoint() {
 
     # Setup the base environment for the test suite
     setup_base_env
-
+    
     # Check if custom ports have been used and if so, outputting a warning message
     if [ "$SERVER_CONTROL_PORT" != "25000" ] || [ "$CLIENT_CONTROL_PORT" != "25001" ] || [ "$S_SERVER_PORT" != "4433" ]; then
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
@@ -496,9 +496,15 @@ function tls_client_test_entrypoint() {
         echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
     fi
 
-    # Output the start message and beginning the initial handshake
+    # Output the waiting message and begin the initial handshake
     echo -e "Client Script Activated, connecting to server...\n"
     control_signal "iteration_handshake"
+    clear
+
+    # Output the test start message
+    echo -e "\n####################################"
+    echo "Performing TLS Handshake Tests"
+    echo "####################################"
 
     # Perform the TLS handshake tests for the specified number of runs
     for run_num in $(seq 1 $NUM_RUN); do

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -495,9 +495,15 @@ function tls_server_test_entrypoint() {
         echo -e "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
     fi
 
-    # Output the start message and beginning the initial handshake
+    # Output the waiting message and begin the initial handshake
     echo -e "Server Script Activated, waiting for connection from client..."
     control_signal "iteration_handshake"
+    clear
+
+    # Output the test start message
+    echo -e "\n####################################"
+    echo "Performing TLS Handshake Tests"
+    echo "####################################"
 
     # Perform the TLS handshake tests for the specified number of runs
     for run_num in $(seq 1 $NUM_RUN); do

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -5,7 +5,7 @@
 
 # Server-side script for executing TLS handshake performance tests in coordination with a remote client. 
 # It evaluates all supported combinations of classic, Post-Quantum Cryptography (PQC), and Hybrid-PQC signature
-# and KEM algorithms using OpenSSL 3.4.1 integrated with the OQS-Provider. The script performs three main test suites:
+# and KEM algorithms using OpenSSL 3.5.0 integrated with the OQS-Provider. The script performs three main test suites:
 # PQC-only, Hybrid-PQC, and Classic handshake tests. It is called by the full-oqs-provider-test.sh benchmarking 
 # controller script and uses globally defined test parameters, certificate and key files, and control signalling 
 # for synchronisation with the client.
@@ -50,7 +50,7 @@ function setup_base_env() {
     util_scripts="$root_dir/scripts/utility-scripts"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     provider_path="$libs_dir/oqs-provider/lib"
 
     # Declare global key storage directory paths

--- a/scripts/test-scripts/oqsprovider-test-server.sh
+++ b/scripts/test-scripts/oqsprovider-test-server.sh
@@ -327,14 +327,15 @@ function pqc_tests() {
 
                 # Start the OpenSSL s_server process
                 "$openssl_path/bin/openssl" s_server \
-                    -cert $cert_file \
-                    -key $key_file \
+                    -cert  "$cert_file" \
+                    -key   "$key_file"  \
+                    -provider default \
+                    -provider oqsprovider \
+                    -provider-path "$provider_path" \
                     -www \
                     -tls1_3 \
-                    -groups $kem \
-                    -provider oqsprovider \
-                    -provider-path $provider_path \
-                    -accept $S_SERVER_PORT &
+                    -groups "$kem" \
+                    -accept "$S_SERVER_PORT" &
                 server_pid=$!
 
                 # Check if the server has started before sending ready signal to client
@@ -514,7 +515,7 @@ function tls_server_test_entrypoint() {
 
         # Set the test type, environment, and call the PQC tests function
         test_type=0
-        set_test_env $test_type 1
+        set_test_env $test_type 2
         pqc_tests
         echo -e "[OUTPUT] - Completed $run_num PQC TLS Handshake Tests"
 
@@ -526,7 +527,7 @@ function tls_server_test_entrypoint() {
 
         # Set the test type, environment, and call the Hybrid-PQC tests function
         test_type=1
-        set_test_env $test_type 1
+        set_test_env $test_type 2
         pqc_tests
         echo "[OUTPUT] - Completed $run_num Hybrid-PQC TLS Handshake Tests"
 
@@ -538,7 +539,7 @@ function tls_server_test_entrypoint() {
 
         # Set the test type, environment, and call the classic tests function
         test_type=2
-        set_test_env $test_type 1
+        set_test_env $test_type 2
         classic_tests
         echo "[OUTPUT] - Completed $run_num Classic TLS Handshake Tests"
 

--- a/scripts/test-scripts/oqsprovider-test-speed.sh
+++ b/scripts/test-scripts/oqsprovider-test-speed.sh
@@ -74,10 +74,10 @@ function setup_test_env() {
     export LD_LIBRARY_PATH="$openssl_lib_path:$LD_LIBRARY_PATH"
 
     # Set the alg-list txt filepaths
-    kem_alg_file="$test_data_dir/alg-lists/tls-kem-algs.txt"
-    sig_alg_file="$test_data_dir/alg-lists/tls-sig-algs.txt"
-    hybrid_kem_alg_file="$test_data_dir/alg-lists/tls-hybr-kem-algs.txt"
-    hybrid_sig_alg_file="$test_data_dir/alg-lists/tls-hybr-sig-algs.txt"
+    kem_alg_file="$test_data_dir/alg-lists/tls-speed-kem-algs.txt"
+    sig_alg_file="$test_data_dir/alg-lists/tls-speed-sig-algs.txt"
+    hybrid_kem_alg_file="$test_data_dir/alg-lists/tls-speed-hybr-kem-algs.txt"
+    hybrid_sig_alg_file="$test_data_dir/alg-lists/tls-speed-hybr-sig-algs.txt"
 
     # Create the PQC KEM and digital signature algorithm list arrays
     kem_algs=()
@@ -124,19 +124,6 @@ function tls_speed_test() {
     sig_algs_string="${sig_algs[@]}"
     hybrid_kem_algs_string="${hybrid_kem_algs[@]}"
     hybrid_sig_algs_string="${hybrid_sig_algs[@]}"
-
-    # Update the naming convention for the MLKEM algorithms to work with the OpenSSL speed utility
-    kem_algs_string=$(echo "$kem_algs_string" | sed -e 's/\bMLKEM512\b/ML-KEM-512/g' \
-                                                -e 's/\bMLKEM768\b/ML-KEM-768/g' \
-                                                -e 's/\bMLKEM1024\b/ML-KEM-1024/g')
-
-    # Remove ML-DSA and SLH-DSA from sig algs as not supported within the OpenSSL speed utility
-    sig_algs_string=$(echo "$sig_algs_string" | tr ' ' '\n' | grep -v -E '^MLDSA|^SLH-DSA' | grep -v '^$' | tr '\n' ' ')
-
-
-    # echo "Kem algs string - $kem_algs_string"
-    # echo -e "\n"
-    # echo "Sig algs string - $sig_algs_string"
 
     # Perform the TLS speed tests for the specified number of runs
     for run_num in $(seq 1 $NUM_RUN); do

--- a/scripts/test-scripts/oqsprovider-test-speed.sh
+++ b/scripts/test-scripts/oqsprovider-test-speed.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 # Script executed from the client machine to benchmark the computational performance of PQC, Hybrid-PQC, and 
-# Classic digital signature and KEM algorithms integrated into OpenSSL 3.4.1 via the OQS-Provider. It receives 
+# Classic digital signature and KEM algorithms integrated into OpenSSL 3.5.0 via the OQS-Provider. It receives 
 # test parameters from the main OQS-Provider test control script and runs OpenSSL's speed utility to collect
 # per-algorithm timing metrics. Results are stored in machine-specific directories under the appropriate 
 # TLS test type, using the assigned machine ID exported by the full-pqc-tls-test.sh script.
@@ -49,7 +49,7 @@ function setup_test_env() {
     util_scripts="$root_dir/scripts/utility-scripts"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     oqs_provider_path="$libs_dir/oqs-provider"
     provider_path="$oqs_provider_path/lib"
 
@@ -117,7 +117,7 @@ function setup_test_env() {
 #-------------------------------------------------------------------------------------------------------------------------------
 function tls_speed_test() {
     # Function for running the TLS speed tests for the various algorithm types. It uses the OpenSSL s_speed utility to benchmark
-    # the performance of the specified algorithms when integrated into OpenSSL 3.4.1 via the OQS-Provider.
+    # the performance of the specified algorithms when integrated into OpenSSL 3.5.0 via the OQS-Provider.
 
     # Joining the elements of algorithm arrays into a string variable to create test parameter
     kem_algs_string="${kem_algs[@]}"

--- a/scripts/test-scripts/oqsprovider-test-speed.sh
+++ b/scripts/test-scripts/oqsprovider-test-speed.sh
@@ -180,6 +180,11 @@ function tls_speed_test_entrypoint() {
     # Setup the base environment for the test suite
     setup_test_env
 
+    # Output the test start message
+    echo -e "\n##########################"
+    echo "Performing TLS Speed Tests"
+    echo -e "##########################"
+
     # Modify the OpenSSL conf file to temporarily remove the default groups configuration
     if ! "$util_scripts/configure-openssl-cnf.sh" 1; then
         echo "[ERROR] - Failed to modify OpenSSL configuration."

--- a/scripts/utility-scripts/configure-openssl-cnf.sh
+++ b/scripts/utility-scripts/configure-openssl-cnf.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 # Utility script for toggling the OpenSSL configuration settings in the openssl.cnf file to enable or 
-# disable post-quantum cryptographic key generation. It comments or uncomments default group directives #
+# disable post-quantum cryptographic key generation. It comments or uncomments default group directives
 # required for compatibility with scheme groups supported by the OQS-Provider when integrated with OpenSSL 3.5.0.
 
 #-------------------------------------------------------------------------------------------------------------------------------
@@ -14,8 +14,9 @@ function output_help_message() {
     # Output the supported options and their usage to the user
     echo "Usage: configure-openssl-cnf.sh [options]"
     echo "Options:"
-    echo "  0                     Configure OpenSSL for standard mode"
-    echo "  1                     Configure OpenSSL for PQC testing mode"
+    echo "  0                     Modify default OpenSSL Configuration file to include OQS-Provider directives (for setup only)"
+    echo "  1                     Configure OpenSSL Configuration for Key Generation mode"
+    echo "  2                     Configure OpenSSL for TLS testing mode"
     echo "  --help                Display this help message and exit"
 
 }
@@ -56,9 +57,24 @@ function parse_args() {
                 ;;
 
             1)
+
                 # Set the configure mode if no mode has been yet
                 if [ "$mode_selected" == "False" ]; then
                     configure_mode=1
+                    mode_selected="True"
+
+                else
+                    echo "[ERROR] - Only one mode can be selected at a time"
+                    exit 1
+                fi
+
+                shift
+                ;;
+
+            2)
+                # Set the configure mode if no mode has been yet
+                if [ "$mode_selected" == "False" ]; then
+                    configure_mode=2
                     mode_selected="True"
 
                 else
@@ -150,22 +166,50 @@ function configure_conf_statements() {
     # key generation with the OQS-Provider.
 
     # Declare the required local variables
-    local conf_path="$openssl_path/openssl.cnf"
+    local openssl_conf_path="$openssl_path/openssl.cnf"
 
     # Set the configurations based on the configuration mode passed
     if [ "$configure_mode" -eq 0 ]; then
 
-        # Comment out the unnecessary lines for standard configuration
-        sed -i 's/ssl_conf = ssl_sect/#ssl_conf = ssl_sect/' $conf_path
-        sed -i 's/system_default = system_default_sect/#system_default = system_default_sect/' $conf_path
-        sed -i 's/Groups = \$ENV::DEFAULT_GROUPS/#Groups = \$ENV::DEFAULT_GROUPS/' $conf_path
+        # Set the OpenSSL configuration array to append onto the end of the file
+        conf_changes=(
+            "[ssl_sect]"
+            "system_default = system_default_sect"
+            "[system_default_sect]"
+            "Groups = \$ENV::DEFAULT_GROUPS"
+        )
 
-    elif [ "$configure_mode" -eq 1 ]; then 
+        # Patch the OpenSSL configuration file to have the correct provider settings
+        sed -i '/^\[openssl_init\]/,/^\[/{ 
+            s/^providers *=.*/providers  = provider_sect/
+            /ssl_conf[[:space:]]*=/d
+            /providers  = provider_sect/a\
+ssl_conf   = ssl_sect
+        }' "$openssl_conf_path"
 
-        # Uncomment the required configurations for PQC testing
-        sed -i 's/^#ssl_conf = ssl_sect/ssl_conf = ssl_sect/' $conf_path
-        sed -i 's/^#system_default = system_default_sect/system_default = system_default_sect/' $conf_path
-        sed -i 's/^#Groups = \$ENV::DEFAULT_GROUPS/Groups = \$ENV::DEFAULT_GROUPS/' $conf_path
+
+        for conf_change in "${conf_changes[@]}"; do
+            echo $conf_change >> "$openssl_conf_path"
+        done
+
+
+    elif [ "$configure_mode" -eq 1 ]; then
+
+        # Comment out PQC-related configuration lines for standard mode
+        sed -i 's/^ssl_conf   = ssl_sect$/#ssl_conf   = ssl_sect/' "$openssl_conf_path"
+        sed -i 's/^\[ssl_sect\]$/#[ssl_sect]/' "$openssl_conf_path"
+        sed -i 's/^system_default = system_default_sect$/#system_default = system_default_sect/' "$openssl_conf_path"
+        sed -i 's/^\[system_default_sect\]$/#[system_default_sect]/' "$openssl_conf_path"
+        sed -i 's/Groups = \$ENV::DEFAULT_GROUPS/#Groups = \$ENV::DEFAULT_GROUPS/' $openssl_conf_path
+
+    elif [ "$configure_mode" -eq 2 ]; then
+
+        # Uncomment PQC-related configuration lines for PQC testing mode
+        sed -i 's/^#ssl_conf   = ssl_sect$/ssl_conf   = ssl_sect/' "$openssl_conf_path"
+        sed -i 's/^#\[ssl_sect\]$/[ssl_sect]/' "$openssl_conf_path"
+        sed -i 's/^#system_default = system_default_sect$/system_default = system_default_sect/' "$openssl_conf_path"
+        sed -i 's/^#\[system_default_sect\]$/[system_default_sect]/' "$openssl_conf_path"
+        sed -i 's/^#Groups = \$ENV::DEFAULT_GROUPS/Groups = \$ENV::DEFAULT_GROUPS/' $openssl_conf_path
 
     fi
 

--- a/scripts/utility-scripts/configure-openssl-cnf.sh
+++ b/scripts/utility-scripts/configure-openssl-cnf.sh
@@ -5,7 +5,7 @@
 
 # Utility script for toggling the OpenSSL configuration settings in the openssl.cnf file to enable or 
 # disable post-quantum cryptographic key generation. It comments or uncomments default group directives #
-# required for compatibility with scheme groups supported by the OQS-Provider when integrated with OpenSSL 3.4.1.
+# required for compatibility with scheme groups supported by the OQS-Provider when integrated with OpenSSL 3.5.0.
 
 #-------------------------------------------------------------------------------------------------------------------------------
 function output_help_message() {
@@ -121,7 +121,7 @@ function setup_base_env() {
     test_scripts_path="$root_dir/scripts/test-scripts"
 
     # Declare the global library directory path variables
-    openssl_path="$libs_dir/openssl_3.4"
+    openssl_path="$libs_dir/openssl_3.5.0"
     liboqs_path="$libs_dir/liboqs"
     oqs_provider_path="$libs_dir/oqs-provider"
 

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -203,20 +203,18 @@ def oqs_provider_extract_algs(test_type, provider_type, output_str):
     algs = []
     hybrid_algs = []
 
-    # Set the regex pattern to match hybrid algorithm prefixes
+    # Set the filter and match variables used in the test types checks
     hybrid_prefix_pattern = re.compile(r'^(rsa[0-9]+|p[0-9]+|x[0-9]+|X25519|X448|SecP256r1|SecP384r1|SecP521r1)[a-zA-Z0-9_-]+$')
+    uov_pattern = re.compile(r'^(p(256|384|521)_)?OV_.*')
+    excluded_algs = ["CROSSrsdp256small", "X448MLKEM1024"]
+    # leave commented until SLH-DSA is supported for TLS handshakes in OpenSSL
+    #native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+|SLH-DSA-[A-Z0-9-]+[a-z]*)$')
 
     # Set the regex pattern to match OpenSSL native PQC algorithms depending on the test type
     if test_type == 0:
         native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+)$')
     else:
         native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+)$')
-
-    # leave commented until SLH-DSA is supported for TLS handshakes in OpenSSL
-    #native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+|SLH-DSA-[A-Z0-9-]+[a-z]*)$')
-
-    # Set the regex pattern for UOV algorithm detection
-    uov_pattern = re.compile(r'^(p(256|384|521)_)?OV_.*')
 
     # Pre-format the output string to remove newlines and split into a list
     pre_algs = output_str.split("\n")
@@ -241,7 +239,7 @@ def oqs_provider_extract_algs(test_type, provider_type, output_str):
             alg = alg.split(" @ ")[0]
 
         # Skip over algorithms that are to be excluded from the list
-        if test_type == 0 and uov_pattern.match(alg) or alg == "CROSSrsdp256small":
+        if test_type == 0 and (uov_pattern.match(alg) or alg in excluded_algs):
             continue
 
         # Determine what filters are needed based on the provider type

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -205,10 +205,13 @@ def oqs_provider_extract_algs(test_type, provider_type, output_str):
 
     # Set the filter and match variables used in the test types checks
     hybrid_prefix_pattern = re.compile(r'^(rsa[0-9]+|p[0-9]+|x[0-9]+|X25519|X448|SecP256r1|SecP384r1|SecP521r1)[a-zA-Z0-9_-]+$')
-    uov_pattern = re.compile(r'^(p(256|384|521)_)?OV_.*')
     excluded_algs = ["CROSSrsdp256small", "X448MLKEM1024"]
     # leave commented until SLH-DSA is supported for TLS handshakes in OpenSSL
     #native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+|SLH-DSA-[A-Z0-9-]+[a-z]*)$')
+
+    # Set the UOV exclude and include patterns
+    uov_exclude_pattern = re.compile(r'^(p(256|384|521)_)?OV_.*')
+    uov_include = ["OV_Ip_pkc", "p256_OV_Ip_pkc", "OV_Ip_pkc_skc", "p256_OV_Ip_pkc_skc"]
 
     # Set the regex pattern to match OpenSSL native PQC algorithms depending on the test type
     if test_type == 0:
@@ -239,7 +242,7 @@ def oqs_provider_extract_algs(test_type, provider_type, output_str):
             alg = alg.split(" @ ")[0]
 
         # Skip over algorithms that are to be excluded from the list
-        if test_type == 0 and (uov_pattern.match(alg) or alg in excluded_algs):
+        if test_type == 0 and ((uov_exclude_pattern.match(alg) and alg not in uov_include) or alg in excluded_algs):
             continue
 
         # Determine what filters are needed based on the provider type

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -195,7 +195,7 @@ def get_liboqs_algs():
             return
 
 #-----------------------------------------------------------------------------------------------------------
-def oqs_provider_extract_algs(output_str):
+def oqs_provider_extract_algs(provider_type, output_str):
     """ Helper function to extract the algorithms from the output string of the OpenSSL binary. The binary is passed 
         the algorithm type and the OQS-Provider flags so that it prints out the algorithms supported for that type in OQS-Provider. """
 
@@ -204,7 +204,10 @@ def oqs_provider_extract_algs(output_str):
     hybrid_algs = []
 
     # Set the regex pattern to match hybrid algorithm prefixes
-    hybrid_prefix_pattern = re.compile(r'^(rsa[0-9]+|p[0-9]+|x[0-9]+)_|^(X25519|SecP256r1|SecP384r1|SecP521r1)[A-Za-z0-9]+$')
+    hybrid_prefix_pattern = re.compile(r'^(rsa[0-9]+|p[0-9]+|x[0-9]+|X25519|X448|SecP256r1|SecP384r1|SecP521r1)[a-zA-Z0-9_-]+$')
+
+    # Set the regex pattern to match OpenSSL native PQC algorithms
+    native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+|SLH-DSA-[A-Z0-9-]+[a-z]*)$')
 
     # Set the regex pattern for UOV algorithm detection
     uov_pattern = re.compile(r'^(p(256|384|521)_)?OV_.*')
@@ -215,20 +218,46 @@ def oqs_provider_extract_algs(output_str):
 
     # Loop through the pre-formatted algorithms and add to the appropriate list
     for alg in pre_algs:
-        
-        # Format the algorithm string to have only the algorithm name
+
+        # Clean up the algorithm string before checks
         alg = alg.strip()
-        alg = alg.split(" @ ")[0]
 
-        # Determine if the algorithm is one that should be included in the generated list
-        if not uov_pattern.match(alg) and alg != "CROSSrsdp256small":
+        # If braces present, get last alias (usually best readable name)
+        if alg.startswith("{"):
 
-            # Determine if the is a hybrid algorithm or not and add to the appropriate list
-            if hybrid_prefix_pattern.match(alg):
+            brace_content = alg.split("}")[0]  # get the content before closing brace
+            items = brace_content.strip("{ ").split(",")
+            alg = items[-1].strip()
+
+        else:
+            # If no braces, get the last part of the string
+            alg = alg.strip()
+            alg = alg.split(" @ ")[0]
+
+        # Skip over algorithms that are to be excluded from the list
+        if uov_pattern.match(alg) or alg == "CROSSrsdp256small":
+            continue
+
+        # Determine what filters are needed based on the provider type
+        if provider_type == "default":
+
+            # Determine if the algorithm is a PQC or Hybrid-PQC algorithm
+            if native_pqc_pattern.match(alg):
+                algs.append(alg.strip())
+            elif hybrid_prefix_pattern.match(alg):
                 hybrid_algs.append(alg.strip())
 
+        elif provider_type == "oqsprovider":
+
+            # Determine if the algorithm is a PQC or Hybrid-PQC algorithm
+            if hybrid_prefix_pattern.match(alg):
+                hybrid_algs.append(alg.strip())
             else:
                 algs.append(alg.strip())
+
+        else:
+            print(f"[ERROR] - Unknown provider type '{provider_type}'")
+            sys.exit(1)
 
     return algs, hybrid_algs
 
@@ -237,25 +266,40 @@ def get_tls_pqc_algs():
     """ Function to get the PQC and Hybrid-PQC algorithms supported by 
         the OQS-Provider library for the TLS benchmarking. """
 
-    # Set required path variables and algorithm categories
+    # Set required path variables, algorithm categories, and provider flags
     openssl_bin = os.path.join(openssl_path, "bin","openssl")
     output_dir = os.path.join(root_dir, "test-data", "alg-lists")
     alg_cats = ["kem", "signature"]
+    provider_flags = {
+        "default": ["-provider", "default"], 
+        "oqsprovider": ["-provider", "oqsprovider", "-provider-path", oqs_provider_path]
+    }
 
     # Loop through the different algorithm types and get the algorithms supported
     for alg_type in alg_cats:
 
-        # Run the openssl binary with the required flags to get the algorithms supported and capture the output
-        process = subprocess.Popen(
-            [openssl_bin, "list", f"-{alg_type}-algorithms", "-provider", "oqsprovider"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
-        )
-        stdout, stderr = process.communicate()
+        # Set the master algorithms lists for the current algorithm type
+        algs = []
+        hybrid_algs = []
 
-        # Extract the PQC and Hybrid-PQC algorithms from the output string
-        algs, hybrid_algs = oqs_provider_extract_algs(stdout)
+        # Loop through each of the provider types that algorithms need to be extracted from
+        for provider_type in provider_flags.keys():
+
+            # Run the openssl binary with the required flags to get the algorithms supported and capture the output
+            process = subprocess.Popen(
+                [openssl_bin, "list", f"-{alg_type}-algorithms"] + provider_flags[provider_type],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True
+            )
+            stdout, stderr = process.communicate()
+
+            # Extract the PQC and Hybrid-PQC algorithms from the output string
+            provider_algs, provider_hybrid_algs = oqs_provider_extract_algs(provider_type, stdout)
+
+            # Append the extracted algorithms to the master lists
+            algs.extend(provider_algs)
+            hybrid_algs.extend(provider_hybrid_algs)
 
         # Set the various output filenames depending on the current algorithm type
         if alg_type == "kem":

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -207,7 +207,10 @@ def oqs_provider_extract_algs(provider_type, output_str):
     hybrid_prefix_pattern = re.compile(r'^(rsa[0-9]+|p[0-9]+|x[0-9]+|X25519|X448|SecP256r1|SecP384r1|SecP521r1)[a-zA-Z0-9_-]+$')
 
     # Set the regex pattern to match OpenSSL native PQC algorithms
-    native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+|SLH-DSA-[A-Z0-9-]+[a-z]*)$')
+    native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+)$')
+
+    # leave commented until SLH-DSA is supported for TLS handshakes in OpenSSL
+    #native_pqc_pattern = re.compile(r'^(MLKEM[0-9]+|MLDSA[0-9]+|SLH-DSA-[A-Z0-9-]+[a-z]*)$')
 
     # Set the regex pattern for UOV algorithm detection
     uov_pattern = re.compile(r'^(p(256|384|521)_)?OV_.*')
@@ -312,7 +315,7 @@ def get_tls_pqc_algs():
             speed_list_file = os.path.join(output_dir, "tls-speed-sig-algs.txt")
             hybrid_alg_list_file = os.path.join(output_dir, "tls-hybr-sig-algs.txt")
 
-        # Write out the algorithms to the list file
+        # Write out the algorithms to the list files
         write_to_file(algs, alg_list_file)
         write_to_file(hybrid_algs, hybrid_alg_list_file)
         write_to_file(algs, speed_list_file)

--- a/scripts/utility-scripts/get_algorithms.py
+++ b/scripts/utility-scripts/get_algorithms.py
@@ -76,7 +76,7 @@ def setup_base_env():
 
     # Declare the global library directory path variables
     liboqs_build_dir = os.path.join(root_dir, "lib", "liboqs", "build", "tests")
-    openssl_path = os.path.join(root_dir, "lib", "openssl_3.4")
+    openssl_path = os.path.join(root_dir, "lib", "openssl_3.5.0")
     oqs_provider_path = os.path.join(root_dir, "lib", "oqs-provider")
     openssl_lib_dir = ""
 

--- a/setup.sh
+++ b/setup.sh
@@ -765,23 +765,6 @@ function openssl_build() {
 
     # Define the path to the OQS-Provider library and the openssl.cnf file changes
     oqsprovider_path="$oqs_provider_path/lib/oqsprovider.so"
-    conf_changes=(
-        "[openssl_init]"
-        "providers = provider_sect"
-        "ssl_conf = ssl_sect"
-        "[provider_sect]"
-        "default = default_sect"
-        "oqsprovider = oqsprovider_sect"
-        "[default_sect]"
-        "activate = 1"
-        "[oqsprovider_sect]"
-        "activate = 1"
-        "module = $oqs_provider_path/lib/oqsprovider.so"
-        "[ssl_sect]"
-        "system_default = system_default_sect"
-        "[system_default_sect]"
-        "Groups = \$ENV::DEFAULT_GROUPS"
-    )
 
     # Check if a previous OpenSSL build is present and build if not
     if [ ! -d "$openssl_path" ]; then
@@ -818,13 +801,11 @@ function openssl_build() {
             exit 1
         fi
 
-        # Set the OpenSSL configuration file path
-        openssl_conf_path="$openssl_path/openssl.cnf"
-
-        # Modify the OpenSSL conf file to include OQS-Provider as a provider
-        for conf_change in "${conf_changes[@]}"; do
-            echo $conf_change >> "$openssl_conf_path"
-        done
+        # Patch the OpenSSL configuration file to include directives for the OQS-Provider library
+        if ! "$util_scripts/configure-openssl-cnf.sh" 0; then
+            echo "[ERROR] - Failed to modify OpenSSL configuration file."
+            exit 1
+        fi
 
     else
         echo "openssl build present, skipping build"

--- a/setup.sh
+++ b/setup.sh
@@ -1105,7 +1105,7 @@ function main() {
                 openssl_build
                 liboqs_build
                 # rm -rf $tmp_dir/*
-                rm -rf $tmp_dir/liboqs-source $tmp_dir/openssl-3.4.1 # temp removal for hqc bug fix
+                rm -rf $tmp_dir/liboqs-source $tmp_dir/openssl-$openssl_version # temp removal for hqc bug fix
 
                 # Create the required alg-list files for the automated testing
                 cd "$util_scripts"
@@ -1133,7 +1133,7 @@ function main() {
                 liboqs_build
                 oqs_provider_build
                 #rm -rf $tmp_dir/* # original cleanup
-                rm -rf $tmp_dir/liboqs-source $tmp_dir/openssl-3.4.1 $tmp_dir/oqs-provider-source # temp removal for hqc bug fix
+                rm -rf $tmp_dir/liboqs-source $tmp_dir/openssl-$openssl_version $tmp_dir/oqs-provider-source # temp removal for hqc bug fix
                 #touch "$tmp_dir/test.flag"
 
                 # Create the required alg-list files for the automated testing
@@ -1157,7 +1157,7 @@ function main() {
                 configure_oqs_provider_build
                 dependency_install
 
-                # Build OpenSSL 3.4.1
+                # Build OpenSSL 3.5.0
                 openssl_build
 
                 # Check if a Liboqs install is already present and install if not
@@ -1171,7 +1171,7 @@ function main() {
                 # Build the OQS-Provider library
                 oqs_provider_build
                 #rm -rf $tmp_dir/* # original cleanup
-                rm -rf $tmp_dir/liboqs-source $tmp_dir/openssl-3.4.1 $tmp_dir/oqs-provider-source # temp removal for hqc bug fix
+                rm -rf $tmp_dir/liboqs-source $tmp_dir/openssl-$openssl_version $tmp_dir/oqs-provider-source # temp removal for hqc bug fix
 
                 # Check if the Liboqs alg-list files are present before deciding which alg-list files need generated
                 if [ -f "$alg_lists_dir/kem-algs.txt" ] && [ -f "$alg_lists_dir/sig-algs.txt" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -18,15 +18,29 @@ test_data_dir="$root_dir/test-data"
 alg_lists_dir="$test_data_dir/alg-lists"
 util_scripts="$root_dir/scripts/utility-scripts"
 
+# Declare the global dependency library version variables
+#liboqs_version="0.13.0"
+#oqs_provider_version="0.8.0"
+openssl_version="3.5.0"
+
+# Declare the global library download URL variables
+#liboqs_download_url=""
+#oqs_provider_download_url=""
+openssl_download_url="https://github.com/openssl/openssl/releases/download/openssl-3.5.0/openssl-3.5.0.tar.gz"
+
+# Declare the global safe library download URL variables
+#liboqs_safe_download_url=""
+#oqs_provider_safe_download_url=""
+
 # Declare the global library directory path variables
-openssl_path="$libs_dir/openssl_3.4"
+openssl_path="$libs_dir/openssl_$openssl_version"
 liboqs_path="$libs_dir/liboqs"
 oqs_provider_path="$libs_dir/oqs-provider"
 
 # Declare the global source-code directory path variables
 liboqs_source="$tmp_dir/liboqs-source"
 oqs_provider_source="$tmp_dir/oqs-provider-source"
-openssl_source="$tmp_dir/openssl-3.4.1"
+openssl_source="$tmp_dir/openssl-$openssl_version"
 
 # Set the global flag variables
 install_type=0 # 0=Liboqs-only, 1=Liboqs+OQS-Provider, 2=OQS-Provider-only
@@ -308,9 +322,9 @@ function download_libraries() {
     echo -e "##############################\n"
 
     # Download OpenSSL 3.4.1 and extract it into the tmp directory
-    wget -O "$tmp_dir/openssl-3.4.1.tar.gz" https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz
-    tar -xf "$tmp_dir/openssl-3.4.1.tar.gz" -C $tmp_dir
-    rm "$tmp_dir/openssl-3.4.1.tar.gz"
+    wget -O "$tmp_dir/openssl-$openssl_version.tar.gz" "$openssl_download_url"
+    tar -xf "$tmp_dir/openssl-$openssl_version.tar.gz" -C $tmp_dir
+    rm "$tmp_dir/openssl-$openssl_version.tar.gz"
 
     # Ensure that the OpenSSL source directory is present before continuing
     if [ ! -d "$openssl_source" ]; then
@@ -733,17 +747,17 @@ function modify_openssl_src() {
 
 #-------------------------------------------------------------------------------------------------------------------------------
 function openssl_build() {
-    # Function for handling the build of the OpenSSL library (version 3.4.1). The function will check if the library is already built
+    # Function for handling the build of the OpenSSL library (version 3.5.0). The function will check if the library is already built
     # and if not, it will build the library using the specified configuration options. The function will call the modify_openssl_src function
     # to modify the speed.c source code file if the OQS-Provider library is being built with the enable all disabled algorithms flag.
 
     # Output the current task to the terminal
     echo -e "\n######################"
-    echo "Building OpenSSL-3.4.1"
+    echo "Building OpenSSL-$openssl_version"
     echo -e "######################\n"
 
     # Output warning message this make take a while to the user
-    echo -e "Starting OpenSSL 3.4.1 build process. This may take a while, and no progress bar will be shown...\n"
+    echo -e "Starting OpenSSL $openssl_version build process. This may take a while, and no progress bar will be shown...\n"
     sleep 2
 
     # Setting CPU thread count for the build process
@@ -799,7 +813,7 @@ function openssl_build() {
         # Testing if the OpenSSL has been correctly installed
         test_output=$("$openssl_path/bin/openssl" version)
 
-        if [[ "$test_output" != "OpenSSL 3.4.1 11 Feb 2025 (Library: OpenSSL 3.4.1 11 Feb 2025)" ]]; then
+        if [[ "$test_output" != "OpenSSL 3.5.0 8 Apr 2025 (Library: OpenSSL 3.5.0 8 Apr 2025)" ]]; then
             echo -e "\n\n[ERROR] - Installing required OpenSSL version failed, please verify install process"
             exit 1
         fi


### PR DESCRIPTION
## Summary

The repository currently uses a local and isolated installation of **OpenSSL 3.4.1** to support the Liboqs and OQS-Provider dependencies. With the release of **OpenSSL 3.5.0**, an upgrade is required to ensure the framework remains compatible with the latest upstream improvements and standards.

Version 3.5 introduces native support for standardised PQC algorithms such as **ML-KEM**, **ML-DSA**, and **SLH-DSA**, which directly affects the way PQC algorithms are handled and registered by OpenSSL and potentially by OQS-Provider. This change will require close attention to compatibility and behaviour changes in the benchmarking and test tooling.

---

## Details

The upgrade will involve the following areas of work:

- **Update Automated Setup Scripts**  
  Modify `setup.sh` and associated tooling to fetch, configure, and build OpenSSL **3.5.0**. Ensure that the build process accounts for changes in default algorithm availability and integrates cleanly with the OQS-Provider configuration.

- **Handle Native PQC Support in OpenSSL 3.5**  
  OpenSSL 3.5 now includes first-party support for standardised PQC algorithms (e.g., ML-KEM). This may:
  - Affect how OQS-Provider registers overlapping algorithms
  - Change how certificates and TLS configurations need to be generated
  - Require additional handling in tools that dynamically list or filter supported algorithms

- **Update and Test TLS Benchmarking Scripts**  
  Investigate and update scripts that generate keys, certificates, and benchmark TLS performance:
  - `oqsssl-generate-keys.sh`
  - `oqsssl-test-server.sh`
  - `oqsssl-test-client.sh`
  - `oqsssl-test-speed.sh`

  These may need changes to avoid conflicts between OpenSSL-native PQC support and OQS-Provider-loaded algorithms.

- **Validate Liboqs Integration**  
  Though Liboqs isn't tightly coupled to OpenSSL, its tooling must still function correctly in the updated environment.

- **Test and Validate OQS-Provider Integration**  
  Rebuild the OQS-Provider with OpenSSL 3.5 and run:
  - TLS handshake benchmarking
  - `openssl speed` PQC testing
  - Algorithm enumeration and detection tools (e.g., `get_algorithms.py`)

---

## Task Breakdown

-  Update `setup.sh` to support building OpenSSL 3.5.0
-  Adapt to OpenSSL 3.5’s native PQC algorithm support
- Update OpenSSL config and environment setup scripts as required
- Verify full compatibility with the OQS-Provider when loaded into OpenSSL 3.5
-  Update TLS benchmarking scripts to avoid naming or registration conflicts
-  Confirm correct behaviour of Liboqs computational benchmarking tools
-  Re-run end-to-end tests on both x86 and ARM
-  Document any setup, usage, or algorithm filtering changes caused by OpenSSL 3.5
