### PR TITLE
Improve Dependency Stability by Defaulting to Verified Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [x] Functioning State*
-- [x] Up to date documentation
+- [ ] Functioning State*
+- [ ] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For details on the project's development and upcoming features, see the project'
 
 ## Contents <!-- omit from toc -->
 - [Supported Hardware and Software](#supported-hardware-and-software)
-- [Supported Crytpographic Algorithms](#supported-crytpographic-algorithms)
+- [Supported Cryptographic Algorithms](#supported-cryptographic-algorithms)
 - [Installation Instructions](#installation-instructions)
   - [Cloning the Repository](#cloning-the-repository)
   - [Choosing Installation Mode](#choosing-installation-mode)
@@ -75,19 +75,21 @@ This version of the repository has been fully tested with the following library 
 
 - OpenSSL Version 3.5.0
 
-The repository is configured to pull the latest versions of the OQS projects while maintaining the listed OpenSSL version. This ensures support for the most up-to-date algorithms available from the OQS project. The setup process includes handling changes in the OQS libraries and helping maintain compatibility as updates are released.
+By default, this repository is configured to use the **last tested versions** of the OQS libraries. This helps ensure that all automation scripts operate reliably with known working versions. The listed OpenSSL version remains fixed at 3.5.0 to maintain compatibility with the OQS-Provider and the project's performance testing tools. For information on the specific commits used for the last tested versions of the dependency libraries, see the [Dependency Libraries](./docs/developer-information/dependency-libraries.md) documentation.
 
-However, as the OQS libraries are still developing projects, if any major changes have occurred to their code bases, this project's automation scripts may not be able to accommodate this. If this does happen, please report an issue to this repositories GitHub page where it will be addressed as soon as possible. In the meantime, it is possible to change the versions of the OQS libraries used by the benchmarking suite. This is detailed further in the [Installation Instructions](#installation-instructions) section.
+While this setup maximises reliability, users who need access to more recent updates may configure the setup process accordingly. However, please note that the OQS libraries are still in active development, and upstream changes may occasionally break compatibility with this project’s automation scripts. This is detailed further in the [Installation Instructions](#installation-instructions) section.
 
-## Supported Crytpographic Algorithms
+If any such issues arise, please report them to this repository’s GitHub Issues page so they can be addressed promptly. Instructions for modifying the library versions used by the benchmarking suite are provided in the Installation Instructions section.
+
+## Supported Cryptographic Algorithms
 For further information on the classical and PQC algorithms this project provides support for, including information on any exclusions, please refer to the following documentation:
 
 [Supported Algorithms](docs/supported-algorithms.md)
 
 ## Installation Instructions
-The standard setup process uses the latest versions of the OQS libraries and performs automatic system detection and installation of the benchmarking suite. It supports various installation modes that determine which OQS libraries are downloaded and built, depending on your environment.
+The standard setup process uses the last tested versions of the OQS libraries to ensure compatibility with this project's automation tools. It also performs automatic system detection and installs all required components for benchmarking. The setup script supports multiple installation modes that determine which OQS-related libraries are downloaded and built, depending on your selected testing configuration.
 
-The main setup script also provides a `safe-mode` option, which can be used if there are any issues with the latest versions of the OQS libraries. When `safe-mode` is enabled, the script downloads and builds the last tested versions of the OQS libraries that are known to work reliably with this project. For more details on using `safe-mode`, see the [Optional Setup Flags](#optional-setup-flags) section.
+While this default configuration prioritises stability, it is possible to configure the setup process to use newer versions of the OQS libraries. This may be useful for testing recent algorithm updates or upstream changes. For more information on this and other advanced setup options, see the [Optional Setup Flags](#optional-setup-flags) section.
 
 The following instructions describe the standard setup process, which is the default and recommended option.
 
@@ -153,8 +155,8 @@ touch .pqc_eval_dir_marker.tmp
 
 ### Optional Setup Flags
 For advanced setup options, including:
-- `safe-mode` for using the last tested versions of the dependency libraries,
-- Custom OpenSSL `speed.c` limits, 
+- Pulling the latest version of the OQS libraries rather than the default tested versions
+- Custom OpenSSL `speed.c` limits
 - Enabling HQC algorithms in Liboqs
  
 Please refer to the [Advanced Setup Configuration Guide](docs/advanced-setup-configuration.md).

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Notice: <!-- omit from toc -->
 This is the **development branch**, it may not be in a fully functioning state and documentation may still need updated. The checkboxes below indicates whether the current development version is in a basic functioning state and if the documentation is accurate for its current functionality. Regardless please keep this in mind and use the main branch if possible, thank you.
 
-- [ ] Functioning State*
-- [ ] Up to date documentation
+- [x] Functioning State*
+- [x] Up to date documentation
 
 ### Main Development Branch Task Tracking
 For full details on the project's development and the current development task lists, please refer to the repositories Github Projects Page here:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For details on the project's development and upcoming features, see the project'
   - [Testing Output Files](#testing-output-files)
 - [Parsing Test Results](#parsing-test-results)
   - [Parsing Overview](#parsing-overview)
+  - [Current Limitations](#current-limitations)
   - [Parsing Script Usage](#parsing-script-usage)
   - [Parsed Results Output](#parsed-results-output)
 - [Additional Documentation](#additional-documentation)
@@ -64,7 +65,6 @@ The automated testing tool is currently only supported in the following environm
 
 - x86 Linux Machines using a Debian-based operating system
 - ARM Linux devices using a 64-bit Debian based Operating System
-- Windows systems, if used **only** for parsing raw performance results
 
 ### Tested Dependency Libraries <!-- omit from toc -->
 This version of the repository has been fully tested with the following library versions:
@@ -216,13 +216,13 @@ The results generated from the automated tests can be parsed into structured CSV
 
 If parsing results for multiple machine-IDs, please ensure that all relevant test results are located in the `test-data/up-results` directory before running the script. When executing the script, you will be prompted to enter the testing parameters, such as the number of machines tested and the number of testing runs conducted in each testing category **†**.
 
-If you run the parsing script on a different system or environment from where the `setup.sh` script was executed, ensure the `pandas` Python package is installed. This is the only external dependency required for parsing. You can install it using:
+### Current Limitations
+The parsing functionality is currently limited to being ran under the following circumstances:
 
-```
-pip install pandas
-```
+- An setup testing environment which contains the algorithm list files that were used to gather the un-parsed results
+- If parsing results from multiple machines, the tests being ran using the same parameters/algorithms lists
 
-> **†** Note: The script currently requires that all machines used for testing ran the same number of test runs in a given testing category (Liboqs/OQS-Provider). If there’s a mismatch, parse each machine’s results separately, then rename and organise the output manually if needed.
+Future work will improve the parsing functionality to remove this limitation and make it easier to generate the parsed results.
 
 ### Parsing Script Usage
 The parsing script can be executed on both Linux and Windows systems. To run it, use the following command (depending on your system's Python alias):

--- a/docs/advanced-setup-configuration.md
+++ b/docs/advanced-setup-configuration.md
@@ -1,20 +1,20 @@
 # Advanced Setup Configurations
 This document outlines additional configuration options when running the `setup.sh` script. The main setup supports the following advanced configurations when called:
 
-- Safe Setup
+- Use the latest versions of the OQS dependency libraries
 - Manually Adjusting OpenSSL's speed Tool Hardcoded Limits
 - Enabling HQC KEM Algorithms in Liboqs
 
-## Safe Setup
-If you encounter compatibility issues with the latest versions of the OQS libraries, you can use **Safe Setup mode**, which installs the last known working versions tested with this project.
-
-To enable the safe setup option, follow the installation process steps as normal, but when calling the `setup.sh` script, supply the `--safe-setup` flag:
+## Using the Latest Versions of the OQS Libraries
+By default, the setup process uses the **last tested versions** of the OQS libraries to ensure compatibility with this project's automation tools. However, users may opt in to use the latest upstream versions of the dependencies by passing the following flag to the setup script:
 
 ```
-./setup.sh --safe-setup
+./setup.sh --latest-dependency-versions
 ```
 
-This will clone the last tested versions of the OQS libraries rather than the version present in the main branches. Please refer to the **Supported Hardware and Software** section in the main [README](../README.md) file for a list of the latest tested versions of the dependency libraries.
+This option may provide access to the most recent algorithm updates and bug fixes, but it may also introduce breaking changes due to upstream modifications. The setup script will display a warning and require explicit confirmation before proceeding with the latest versions.
+
+For more information on the specific versions used by default, see the [Dependency Libraries](./developer-information/dependency-libraries.md) documentation.
 
 ## Adjusting OpenSSL speed Tool Hardcoded Limits
 When enabling all disabled digital signature algorithms during the OQS-Provider setup, the number of registered algorithms can exceed OpenSSL's internal limits. This causes the OpenSSL `s_speed` benchmarking tool to fail due to hardcoded values (`MAX_KEM_NUM` and `MAX_SIG_NUM`) in its source code.

--- a/docs/developer-information/dependency-libraries.md
+++ b/docs/developer-information/dependency-libraries.md
@@ -1,0 +1,16 @@
+# Dependency Libraries
+
+This document lists the **specific commits** used as the last tested versions of the project's core dependencies. These versions are pinned by default during setup to ensure compatibility with the PQC-Evaluation-Tools benchmarking framework.
+
+## Last Tested Versions
+
+| **Dependency** | **Version Context**    | **Commit SHA**                             | **Notes**                                        |
+|----------------|------------------------|--------------------------------------------|--------------------------------------------------|
+| Liboqs         | Post-0.13.0            | `b75bfb8c56d23a92227b04c096f0264b992de874` | Commit after 0.13.0 release, before 0.14.0       |
+| OQS-Provider   | Pre-0.9.0              | `f8cb2c8307e4c95c5bb20f738f3e8a865e5a3ad9` | Commit after 0.8.0, not yet part of 0.9.0 tag    |
+| OpenSSL        | Official release 3.5.0 | N/A                                        | Downloaded as a fixed release tarball            |
+| pqax           | Always latest          | N/A                                        | Pulled from latest `main` branch at install time |
+
+> **Note:** These versions are used by default unless the `--latest-dependency-versions` flag is explicitly set during setup.
+
+For installation instructions, see the [Installation Instructions](../README.md#installation-instructions).

--- a/docs/developer-information/project-scripts.md
+++ b/docs/developer-information/project-scripts.md
@@ -51,7 +51,7 @@ Key tasks performed include:
 
 - Downloading and compiling OpenSSL 3.5.0
 
-- Cloning and building specific or last-tested versions of Liboqs and OQS-Provider
+- Cloning and building the last-tested or latest versions of Liboqs and OQS-Provider
 
 - Modifying OpenSSL’s speed.c to support extended algorithm counts when needed
 
@@ -67,11 +67,11 @@ The script also handles the automatic detection of the system architecture and a
 
 The script is run interactively but supports the following optional arguments for advanced use:
 
-```
---safe-setup                   Use last-tested commits of all libraries  
---set-speed-new-value=<int>    Manually set MAX_KEM_NUM/MAX_SIG_NUM in speed.c
---enable-hqc-algs              Enable HQC KEM algorithms in Liboqs (default: disabled due to security concerns)  
-```
+| **Flag**                       | **Description**                                                                         |
+|--------------------------------|-----------------------------------------------------------------------------------------|
+| `--latest-dependency-versions` | Use the latest available versions of the OQS libraries (may cause compatibility issues) |
+| `--set-speed-new-value=<int>`  | Manually set `MAX_KEM_NUM` and `MAX_SIG_NUM` in OpenSSL’s `speed.c`                     |
+| `--enable-hqc-algs`            | Enable HQC KEM algorithms in Liboqs (default: disabled due to known vulnerability)      |
 
 For further information on the main setup script's usage, please refer to the main [README](../../README.md) file.
 
@@ -95,12 +95,12 @@ The script supports the following functionality:
 
 The utility script accepts the following arguments:
 
-| Argument | Functionality                                                                                                                 |
-|----------|-------------------------------------------------------------------------------------------------------------------------------|
-| `1`      | Extracts algorithms for **Liboqs only**.                                                                                      |
-| `2`      | Extracts algorithms for **both Liboqs and OQS-Provider**.                                                                     |
-| `3`      | Extracts algorithms for **OQS-Provider only**.                                                                                |
-| `4`      | Parses `ALGORITHMS.md` from **OQS-Provider** to determine the total number of supported algorithms (used only by `setup.sh`). |
+| **Argument** | **Functionality**                                                                                                             |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `1`          | Extracts algorithms for **Liboqs only**.                                                                                      |
+| `2`          | Extracts algorithms for **both Liboqs and OQS-Provider**.                                                                     |
+| `3`          | Extracts algorithms for **OQS-Provider only**.                                                                                |
+| `4`          | Parses `ALGORITHMS.md` from **OQS-Provider** to determine the total number of supported algorithms (used only by `setup.sh`). |
 
 While running option `4` manually will work, it is unnecessary. This function is used exclusively by the `setup.sh` script to modify OpenSSL’s `speed.c` file when all OQS-Provider algorithms are enabled. Unlike the other arguments, it does not alter or create files in the repository; it only returns the algorithm count for use during setup.
 
@@ -126,16 +126,11 @@ These adjustments ensure compatibility with both OpenSSL's native PQC support an
 
 When called, the utility script accepts the following arguments:
 
-| Argument | Functionality                                                                                                                                                                             |
-|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `0`      | Performs initial setup by appending OQS-Provider-related directives to the `openssl.cnf` file. **This should only ever be called during setup when modifying the default OpenSSL conf file.** |
-| `1`      | Configures the OpenSSL environment for **key generation benchmarking** by commenting out PQC-related configuration lines.                                                                 |
-| `2`      | Configures the OpenSSL environment for **TLS handshake benchmarking** by uncommenting PQC-related configuration lines.                                                                    |
-
-
-
-
-
+| **Argument** | **Functionality**                                                                                                                                                                             |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `0`          | Performs initial setup by appending OQS-Provider-related directives to the `openssl.cnf` file. **This should only ever be called during setup when modifying the default OpenSSL conf file.** |
+| `1`          | Configures the OpenSSL environment for **key generation benchmarking** by commenting out PQC-related configuration lines.                                                                     |
+| `2`          | Configures the OpenSSL environment for **TLS handshake benchmarking** by uncommenting PQC-related configuration lines.                                                                        |
 
 ## Liboqs Automated Testing Scripts 
 The Liboqs PQC performance testing utilises a single bash script to conduct the automated benchmarking. This script performs CPU speed testing and memory usage profiling for supported KEM and digital signature algorithms. It is designed to be run interactively, prompting the user for test parameters such as the machine ID and number of test iterations.
@@ -179,13 +174,13 @@ The script accepts the passing of various arguments when called, which allows th
 
 **Accepted Script Arguments:**
 
-```
---server-control-port=<PORT>    Set the server control port   (1024-65535)
---client-control-port=<PORT>    Set the client control port   (1024-65535)
---s-server-port=<PORT>          Set the OpenSSL S_Server port (1024-65535)
---control-sleep-time=<TIME>     Set the control sleep time in seconds (integer or float)
---disable-control-sleep         Disable the control signal sleep time
-```
+| **Flag**                       | **Description**                                          |
+|--------------------------------|----------------------------------------------------------|
+| `--server-control-port=<PORT>` | Set the server control port   (1024-65535)               |
+| `--client-control-port=<PORT>` | Set the client control port   (1024-65535)               |
+| `--s-server-port=<PORT>`       | Set the OpenSSL S_Server port (1024-65535)               |
+| `--control-sleep-time=<TIME>`  | Set the control sleep time in seconds (integer or float) |
+| `--disable-control-sleep`      | Disable the control signal sleep time                    |
 
 ### oqsprovider-test-server.sh
 This script handles the server-side operations for the automated TLS handshake performance testing. It performs tests across various combinations of PQC and Hybrid-PQC digital signature and KEM algorithms, as well as classical-only handshakes. The script includes error handling and will coordinate with the client to retry failed tests using control signalling. This script is intended to be called only by the `full-oqs-provider.sh` script and **cannot be run manually**.

--- a/docs/supported-algorithms.md
+++ b/docs/supported-algorithms.md
@@ -9,6 +9,8 @@ The PQC-Evaluation-Tools project provides support for all the PQC algorithms pro
 - [OpenSSL Supported PQC Algorithms](https://github.com/openssl/openssl/releases/tag/openssl-3.5.0)
 - [OQS-Provider Supported Algorithms](https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md)
 
+> **Notice:** If you use the --latest-dependency-versions flag with the main setup script to pull the most recent versions of the OQS libraries, the supported algorithms may differ from what is documented here. This documentation reflects support based on the last tested versions of the dependencies and may not be accurate for upstream updates.
+
 ## Contents <!-- omit from toc -->
 - [Liboqs Algorithms](#liboqs-algorithms)
   - [Algorithm Support Summary](#algorithm-support-summary)

--- a/docs/testing-tools-usage/oqsprovider-performance-testing.md
+++ b/docs/testing-tools-usage/oqsprovider-performance-testing.md
@@ -155,11 +155,11 @@ The currently supported testing customisation options are as follows:
 ### Customising Testing Suite TCP Ports
 If the benchmark scripts' default TCP ports are unsuitable for your environment, custom ports can be specified when launching the test script. This can be done independently for the server and client by passing the following flags:
 
-```
---server-control-port=<PORT>    Set the server control port   (1024-65535)
---client-control-port=<PORT>    Set the client control port   (1024-65535)
---s-server-port=<PORT>          Set the OpenSSL S_Server port (1024-65535)
-```
+| **Flag**                       | **Description**                            |
+|--------------------------------|--------------------------------------------|
+| `--server-control-port=<PORT>` | Set the server control port   (1024-65535) |
+| `--client-control-port=<PORT>` | Set the client control port   (1024-65535) |
+| `--s-server-port=<PORT>`       | Set the OpenSSL S_Server port (1024-65535) |
 
 **When using custom TCP ports**, please ensure the same values are provided to both the server and client instances. Otherwise, the testing will fail.
 
@@ -168,10 +168,10 @@ By default, the tool uses a 0.25 second delay when sending control signals betwe
 
 If the default control signalling timing behaviour is unsuitable for your testing environment, you can customise the control signal sleep time or disable it entirely when executing the `full-oqs-provider-test.sh` script. You can do this by including the following flags:
 
-```
---control-sleep-time=<TIME>     Set the control sleep time in seconds (integer or float)
---disable-control-sleep         Disable the control signal sleep time
-```
+| **Flag**                      | **Description**                                          |
+|-------------------------------|----------------------------------------------------------|
+| `--control-sleep-time=<TIME>` | Set the control sleep time in seconds (integer or float) |
+| `--disable-control-sleep`     | Disable the control signal sleep time                    |
 
 **Please note** that the `--control-sleep-time` flag cannot be used with the `--disable-control-sleep` flag.
 


### PR DESCRIPTION
## Summary
To improve long-term stability and reduce maintenance overhead, the repository’s dependency management will be restructured. Currently, the setup process pulls the latest versions of `Liboqs`, `OQS-Provider`, and `pqax` by default. While this provides access to the latest updates, it frequently introduces unexpected breaking changes that require urgent patching.

Going forward, the default behavior will shift to pulling the last tested and verified versions of all critical dependencies. A new `--use-latest-deps` flag will be introduced for users who wish to opt into the latest upstream changes for development or experimentation.

## Task Details
- Change the default setup to use pinned, last-tested versions of dependencies  
- Add a `--use-latest-deps` flag to allow users to opt into using the latest versions  
- Remove or replace the existing `--safe-setup` flag to avoid confusion  
- Revise related documentation, including README and setup guides  
- Ensure version updates are tested and incorporated in future minor releases

This update will make the repository more stable by default, while still enabling cutting-edge experimentation for advanced users.