### PR TITLE
Fix mistake in OpenSSL supported KEM algs table

### DIFF
--- a/docs/supported_algorithms.md
+++ b/docs/supported_algorithms.md
@@ -344,7 +344,7 @@ These schemes help assess the overhead and feasibility of PQC adoption in real-w
 | **Algorithm Name** | **Hybrid Algorithm (*)** | **TLS Handshake Test Support (*)** | **OpenSSL Speed Test Support (*)** |
 |--------------------|:------------------------:|:----------------------------------:|:----------------------------------:|
 | MLKEM512           |                          |                  *                 |                  *                 |
-| MLKEM768           |                          |                  *                 |                                    |
+| MLKEM768           |                          |                  *                 |                  *                 |
 | MLKEM1024          |                          |                  *                 |                  *                 |
 | X25519MLKEM768     |             *            |                  *                 |                  *                 |
 | X448MLKEM1024      |             *            |                                    |                  *                 |


### PR DESCRIPTION
## Summary
During a review of the OpenSSL supported algorithms, a discrepancy was spotted for `ML-KEM-78` where the documentation incorrectly lists this algorithm as not being supported for TLS speed testing. This will need updated so that documentation correctly represents what testing can be performed with this scheme.

## Task Details
- Adjust the OpenSSL supported algorithm table for ML-KEM