### PR TITLE
Fix shutil.rmtree silently deleting entire results parent directory

### DIFF
--- a/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
+++ b/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
@@ -74,7 +74,7 @@ def handle_results_dir_creation(machine_id, dir_paths, replace_old_results):
 
             # Remove the old results directory automatically for current Machine-ID
             print(f"Removing old results directory for Machine-ID ({machine_id}) before continuing...\n")
-            shutil.rmtree(dir_paths["results_dir"], f"machine_{machine_id}")
+            shutil.rmtree(os.path.join(dir_paths["results_dir"], f"machine_{machine_id}"))
 
             # Create the new directories for parsed results
             os.makedirs(dir_paths["type_speed_dir"])
@@ -99,7 +99,7 @@ def handle_results_dir_creation(machine_id, dir_paths, replace_old_results):
 
                     # Replace all old results and create a new empty directory to store the parsed results
                     print(f"Removing old results directory for Machine-ID ({machine_id}) before continuing...\n")
-                    shutil.rmtree(dir_paths["results_dir"], f"machine_{machine_id}")
+                    shutil.rmtree(os.path.join(dir_paths["results_dir"], f"machine_{machine_id}"))
 
                     # Create the new directories for parsed results
                     os.makedirs(dir_paths["type_speed_dir"])

--- a/scripts/parsing_scripts/internal_scripts/tls_performance_data_parse.py
+++ b/scripts/parsing_scripts/internal_scripts/tls_performance_data_parse.py
@@ -116,7 +116,7 @@ def handle_results_dir_creation(machine_id, dir_paths, replace_old_results):
 
             # Replace all old results and create a new empty directory to store the parsed results
             print(f"Removing old results directory for Machine-ID ({machine_id}) before continuing...\n")
-            shutil.rmtree(dir_paths["results_dir"], f"machine_{machine_id}")
+            shutil.rmtree(os.path.join(dir_paths["results_dir"], f"machine_{machine_id}"))
 
             # Create the new directories for parsed results
             os.makedirs(dir_paths["mach_handshake_dir"])
@@ -141,7 +141,7 @@ def handle_results_dir_creation(machine_id, dir_paths, replace_old_results):
 
                     # Replace all old results and create a new empty directory to store the parsed results
                     print(f"Removing old results directory for Machine-ID ({machine_id}) before continuing...\n")
-                    shutil.rmtree(dir_paths["results_dir"], f"machine_{machine_id}")
+                    shutil.rmtree(os.path.join(dir_paths["results_dir"], f"machine_{machine_id}"))
 
                     # Create the new directories for parsed results
                     os.makedirs(dir_paths["mach_handshake_dir"])


### PR DESCRIPTION
Fixes #99

Four call sites in the parser pass `f"machine_{machine_id}"` as the second positional argument to `shutil.rmtree`. The second positional argument is `ignore_errors`, not a sub-path component. The string was silently treated as a truthy `ignore_errors` flag, so the deletion target was the results parent directory (`results_dir`) instead of the per-machine subdirectory (`results_dir/machine_$N`). This silently destroyed every other machine's parsed results when a user re-parsed one machine with `--replace-old-results` (or interactively chose "Option 1 - Replace old parsed results").

Wrap the path with `os.path.join` so the per-machine subdir is the actual deletion target.

## Affected lines (all fixed)

- `scripts/parsing_scripts/internal_scripts/performance_data_parse.py:77`
- `scripts/parsing_scripts/internal_scripts/performance_data_parse.py:102`
- `scripts/parsing_scripts/internal_scripts/tls_performance_data_parse.py:119`
- `scripts/parsing_scripts/internal_scripts/tls_performance_data_parse.py:144`

`performance_data_parse.py:192` is `shutil.rmtree(dir_paths["up_speed_dir"])` (single arg, correct) and is untouched.

## Testing

`python3 -m py_compile` clean on both modules. No unit-test infrastructure exists in this codebase for the parser. Happy to add targeted tests if you would prefer, though that would expand the PR considerably beyond the four-line fix.