### PR TITLE
Rename computational alg-list files to library-aware names

### DIFF
--- a/cleaner.sh
+++ b/cleaner.sh
@@ -140,8 +140,8 @@ function select_uninstall_mode() {
             1)
                 # Uninstall Liboqs only
                 rm -rf "$liboqs_path"
-                rm "$test_data_alg_lists_dir/kem_algs.txt"
-                rm "$test_data_alg_lists_dir/sig_algs.txt"
+                rm "$test_data_alg_lists_dir/kem_algs_liboqs.txt"
+                rm "$test_data_alg_lists_dir/sig_algs_liboqs.txt"
                 echo -e "\nLiboqs Uninstalled"
                 break;;
             

--- a/docs/performance_results/parsing_scripts_usage_guide.md
+++ b/docs/performance_results/parsing_scripts_usage_guide.md
@@ -64,21 +64,24 @@ Parsing parameters can also be supplied directly as command-line arguments. This
 Command-line mode can also be executed manually, as seen in the example below:
 
 ```
-python3 parse_results.py --parse-mode=computational --machine-id=2 --total-runs=10
+python3 parse_results.py --parse-mode=computational --library=liboqs --machine-id=2 --total-runs=10
 ```
 
 The table below outlines each of the accepted commands that are required for operation:
 
-| **Argument**            | **Description**                                                                        | **Required Flag (*)** |
-|-------------------------|----------------------------------------------------------------------------------------|-----------------------|
-| `--parse-mode=<str>`    | Must be either computational or tls, both is not allowed here.                         | *                     |
-| `--machine-id=<int>`    | Machine-ID used during testing (positive integer).                                     | *                     |
-| `--total-runs=<int>`    | Number of test runs (must be > 0).                                                     | *                     |
-| `--replace-old-results` | Optional flag to force overwrite of any existing results for the specified Machine-ID. |                       |
+| **Argument**            | **Description**                                                                                                                          | **Required Flag (*)** |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+| `--parse-mode=<str>`    | Must be either computational or tls, both is not allowed here.                                                                           | *                     |
+| `--library=<str>`       | PQC library that produced the results being parsed (default: `liboqs`). Only consulted for `--parse-mode=computational`.                  |                       |
+| `--machine-id=<int>`    | Machine-ID used during testing (positive integer).                                                                                       | *                     |
+| `--total-runs=<int>`    | Number of test runs (must be > 0).                                                                                                       | *                     |
+| `--replace-old-results` | Optional flag to force overwrite of any existing results for the specified Machine-ID.                                                   |                       |
 
 This mode is suited for automated workflows or environments where manual input is impractical.
 
 **Note:** The `--parse-mode` argument cannot be set to both. If you wish to parse both computational and TLS performance results in one session, you must use the script in interactive mode.
+
+**Note:** The `--library` argument is the extension point for adding new PQC backend libraries to the parser. The currently supported value is `liboqs`; future libraries will plug in additional values. If unset, the parser defaults to `liboqs` so that existing scripts and workflows continue to work without modification.
 
 ## Parsed Results Output
 Once parsing is complete, the parsed results will be stored in the newly created `test_data/results` directory. This includes CSV files containing the detailed test results and automatically calculated averages for each test category. These files are ready for further analysis or can be imported into graphing tools for visualisation.

--- a/scripts/parsing_scripts/internal_scripts/library_config.py
+++ b/scripts/parsing_scripts/internal_scripts/library_config.py
@@ -1,0 +1,26 @@
+"""
+Copyright (c) 2023-2026 Callum Turino
+SPDX-License-Identifier: MIT
+
+Library-specific configuration for the parsing system. This module defines per-library
+metadata (such as raw-result filename prefixes) consumed by the parsing scripts so that
+adding a new PQC benchmark backend only requires plugging a new entry into the dict
+below, rather than editing the parser itself.
+
+The parsing scripts treat the keys of LIBRARY_PREFIXES as the authoritative list of
+supported libraries; the SUPPORTED_LIBRARIES list is provided for convenience.
+"""
+
+# Mapping of library identifier (as accepted by the --library CLI flag) to the
+# filename prefixes used by that library's raw speed-result CSVs. Future libraries
+# (e.g., wolfSSL, CIRCL) add their entries here.
+LIBRARY_PREFIXES = {
+    "liboqs": {
+        "kem_speed": "test_kem_speed_",
+        "sig_speed": "test_sig_speed_",
+    },
+}
+
+# Ordered list of supported library identifiers. Derived from LIBRARY_PREFIXES so
+# the two cannot drift.
+SUPPORTED_LIBRARIES = list(LIBRARY_PREFIXES.keys())

--- a/scripts/parsing_scripts/internal_scripts/library_config.py
+++ b/scripts/parsing_scripts/internal_scripts/library_config.py
@@ -12,12 +12,19 @@ supported libraries; the SUPPORTED_LIBRARIES list is provided for convenience.
 """
 
 # Mapping of library identifier (as accepted by the --library CLI flag) to the
-# filename prefixes used by that library's raw speed-result CSVs. Future libraries
+# per-library filename conventions used across the test pipeline. Future libraries
 # (e.g., wolfSSL, CIRCL) add their entries here.
+#
+# Per-library keys:
+#   kem_speed / sig_speed   - filename prefix of raw speed-result CSVs, run number appended
+#   kem_algs_file / sig_algs_file - basename of the algorithm-list file under
+#                                   test_data/alg_lists/ (full filename including .txt)
 LIBRARY_PREFIXES = {
     "liboqs": {
         "kem_speed": "test_kem_speed_",
         "sig_speed": "test_sig_speed_",
+        "kem_algs_file": "kem_algs_liboqs.txt",
+        "sig_algs_file": "sig_algs_liboqs.txt",
     },
 }
 

--- a/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
+++ b/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
@@ -16,6 +16,7 @@ import sys
 import shutil
 import time
 from internal_scripts.results_averager import ComputationalAverager
+from internal_scripts.library_config import LIBRARY_PREFIXES
 
 #------------------------------------------------------------------------------------------------------------------------------
 def setup_parse_env(root_dir):
@@ -181,7 +182,7 @@ def get_peak(mem_file, peak_metrics):
                     return peak_metrics
 
 #------------------------------------------------------------------------------------------------------------------------------
-def pre_speed_processing(dir_paths, num_runs):
+def pre_speed_processing(dir_paths, num_runs, library):
     """ Function for preparing speed up-result data by removing system information, 
         making it ready for further processing. """
 
@@ -192,9 +193,9 @@ def pre_speed_processing(dir_paths, num_runs):
         shutil.rmtree(dir_paths["up_speed_dir"])
         os.makedirs(dir_paths['up_speed_dir'])
 
-    # Setting the initial prefix variables for KEM and sig files
-    kem_prefix = "test_kem_speed_"
-    sig_prefix = "test_sig_speed_"
+    # Look up the per-library filename prefixes for KEM and sig speed CSVs
+    kem_prefix = LIBRARY_PREFIXES[library]["kem_speed"]
+    sig_prefix = LIBRARY_PREFIXES[library]["sig_speed"]
 
     # Pre-format the KEM and sig csv speed files to remove system information from the file
     for run_count in range(1, num_runs+1):
@@ -236,13 +237,13 @@ def pre_speed_processing(dir_paths, num_runs):
         sig_pre_speed_df.to_csv(speed_dest_dir, index=False, sep="|")
 
 #------------------------------------------------------------------------------------------------------------------------------
-def speed_processing(dir_paths, num_runs, kem_algs, sig_algs):
+def speed_processing(dir_paths, num_runs, kem_algs, sig_algs, library):
     """ Function for processing CPU speed up-results and exporting the data 
         into a clean CSV format. """
 
-    # Set the filename prefix variables
-    kem_prefix = "test_kem_speed_"
-    sig_prefix = "test_sig_speed_"
+    # Look up the per-library filename prefixes for KEM and sig speed CSVs
+    kem_prefix = LIBRARY_PREFIXES[library]["kem_speed"]
+    sig_prefix = LIBRARY_PREFIXES[library]["sig_speed"]
 
     # Create the algorithm lists to insert into new header column
     new_col_kem = [alg for alg in kem_algs for _ in range(3)]
@@ -423,7 +424,7 @@ def memory_processing(dir_paths, num_runs, kem_algs, sig_algs, alg_operations):
         mem_results_df.to_csv(sig_filepath, index=False)
 
 #------------------------------------------------------------------------------------------------------------------------------
-def process_tests(machine_id, num_runs, dir_paths, kem_algs, sig_algs, replace_old_results):
+def process_tests(machine_id, num_runs, dir_paths, kem_algs, sig_algs, replace_old_results, library):
     """ Function for parsing results for one or more machines, storing them as CSV files, 
         and calculating averages once the up-results are processed. """
 
@@ -431,7 +432,7 @@ def process_tests(machine_id, num_runs, dir_paths, kem_algs, sig_algs, replace_o
     alg_operations = {'kem_operations': ["keygen", "encaps", "decaps"], 'sig_operations': ["keypair", "sign", "verify"]}
 
     # Create an instance of the computational performance average generator class before processing results
-    comp_avg = ComputationalAverager(dir_paths, kem_algs, sig_algs, num_runs, alg_operations)
+    comp_avg = ComputationalAverager(dir_paths, kem_algs, sig_algs, num_runs, alg_operations, library)
 
     # Set the unparsed-directory paths in the central paths dictionary
     dir_paths['up_speed_dir'] = os.path.join(dir_paths['up_results'], f"machine_{str(machine_id)}", "speed_results")
@@ -449,8 +450,8 @@ def process_tests(machine_id, num_runs, dir_paths, kem_algs, sig_algs, replace_o
     handle_results_dir_creation(machine_id, dir_paths, replace_old_results)
 
     # Parse the up-results for the specified Machine-ID
-    pre_speed_processing(dir_paths, num_runs)
-    speed_processing(dir_paths, num_runs, kem_algs, sig_algs)
+    pre_speed_processing(dir_paths, num_runs, library)
+    speed_processing(dir_paths, num_runs, kem_algs, sig_algs, library)
     memory_processing(dir_paths, num_runs, kem_algs, sig_algs, alg_operations)
 
     # Call the average generation methods for memory and CPU performance results
@@ -466,11 +467,19 @@ def parse_comp_performance(test_opts, replace_old_results):
     machine_id = test_opts[0]
     num_runs = test_opts[1]
     root_dir = test_opts[2]
+    # Library identifier: present in test_opts when supplied; default to liboqs for
+    # callers that still pass a 3-element opts list.
+    library = test_opts[3] if len(test_opts) > 3 else "liboqs"
+
+    # Validate the library identifier against the supported set
+    if library not in LIBRARY_PREFIXES:
+        print(f"[ERROR] - Unsupported library identifier '{library}' passed to parse_comp_performance")
+        sys.exit(1)
 
     # Setup the script environment
-    print(f"\nPreparing to parse Computational Performance Results:\n")
+    print(f"\nPreparing to parse Computational Performance Results ({library}):\n")
     kem_algs, sig_algs, dir_paths = setup_parse_env(root_dir)
 
     # Process the results
     print(f"Parsing results...\n")
-    process_tests(machine_id, num_runs, dir_paths, kem_algs, sig_algs, replace_old_results)
+    process_tests(machine_id, num_runs, dir_paths, kem_algs, sig_algs, replace_old_results, library)

--- a/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
+++ b/scripts/parsing_scripts/internal_scripts/performance_data_parse.py
@@ -19,10 +19,11 @@ from internal_scripts.results_averager import ComputationalAverager
 from internal_scripts.library_config import LIBRARY_PREFIXES
 
 #------------------------------------------------------------------------------------------------------------------------------
-def setup_parse_env(root_dir):
+def setup_parse_env(root_dir, library):
     """ Function for setting up the environment for parsing computational performance results.
         The function will set the various directory paths, read in the algorithm 
-        lists and set the root directories. """
+        lists and set the root directories. The alg-list filenames are resolved per-library
+        from LIBRARY_PREFIXES so each backend can ship its own alg list alongside others. """
 
     # Declare the algorithm list and directory paths dict variables
     kem_algs = []
@@ -39,9 +40,9 @@ def setup_parse_env(root_dir):
     dir_paths['results_dir'] = os.path.join(root_dir, "test_data", "results", "computational_performance")
     dir_paths['up_results'] = os.path.join(root_dir, "test_data", "up_results", "computational_performance")
 
-    # Set the alg lists text filenames
-    kem_algs_file = os.path.join(root_dir, "test_data", "alg_lists", "kem_algs.txt")
-    sig_algs_file = os.path.join(root_dir, "test_data", "alg_lists", "sig_algs.txt")
+    # Set the alg lists text filenames (per-library names)
+    kem_algs_file = os.path.join(root_dir, "test_data", "alg_lists", LIBRARY_PREFIXES[library]["kem_algs_file"])
+    sig_algs_file = os.path.join(root_dir, "test_data", "alg_lists", LIBRARY_PREFIXES[library]["sig_algs_file"])
 
     # Read in the algorithms from the KEM alg-list file
     with open(kem_algs_file, "r") as kem_file:
@@ -478,7 +479,7 @@ def parse_comp_performance(test_opts, replace_old_results):
 
     # Setup the script environment
     print(f"\nPreparing to parse Computational Performance Results ({library}):\n")
-    kem_algs, sig_algs, dir_paths = setup_parse_env(root_dir)
+    kem_algs, sig_algs, dir_paths = setup_parse_env(root_dir, library)
 
     # Process the results
     print(f"Parsing results...\n")

--- a/scripts/parsing_scripts/internal_scripts/results_averager.py
+++ b/scripts/parsing_scripts/internal_scripts/results_averager.py
@@ -12,16 +12,20 @@ for memory, CPU speed, and TLS handshake, and TLS speed results, and exports the
 import pandas as pd
 import os
 import numpy as np
+from internal_scripts.library_config import LIBRARY_PREFIXES
 
 #------------------------------------------------------------------------------------------------------------------------------
 class ComputationalAverager:
 
     #------------------------------------------------------------------------------
-    def __init__(self, dir_paths, kem_algs, sig_algs, num_runs, alg_operations):
+    def __init__(self, dir_paths, kem_algs, sig_algs, num_runs, alg_operations, library="liboqs"):
         """ Class for generating average metrics from computational performance results.
             Computes per-algorithm averages across multiple benchmarking runs for both 
             memory usage and CPU speed results. Called by the computational performance parsing 
-            script after results have been processed into structured CSVs. """
+            script after results have been processed into structured CSVs.
+
+            The library parameter identifies which PQC backend produced the inputs; it drives
+            per-library filename prefix selection for the speed-result CSVs. """
 
         # Set the global class variables used in the class methods
         self.dir_paths = dir_paths
@@ -29,6 +33,7 @@ class ComputationalAverager:
         self.kem_algs = kem_algs
         self.sig_algs = sig_algs
         self.alg_operations = alg_operations
+        self.library = library
 
     #------------------------------------------------------------------------------
     def avg_mem(self):
@@ -131,13 +136,17 @@ class ComputationalAverager:
             results and generating an average for all the runs for
             the machine-ID included in the results paths """
 
+        # Look up the per-library filename prefixes for the speed-result CSVs
+        kem_speed_prefix = LIBRARY_PREFIXES[self.library]["kem_speed"]
+        sig_speed_prefix = LIBRARY_PREFIXES[self.library]["sig_speed"]
+
         # Declare the filepath prefix variables and fieldnames list
-        kem_filename_prefix = os.path.join(self.dir_paths['type_speed_dir'], "test_kem_speed_")
-        sig_filename_prefix = os.path.join(self.dir_paths['type_speed_dir'], "test_sig_speed_")
+        kem_filename_prefix = os.path.join(self.dir_paths['type_speed_dir'], kem_speed_prefix)
+        sig_filename_prefix = os.path.join(self.dir_paths['type_speed_dir'], sig_speed_prefix)
         speed_fieldnames = []
 
         # Get the fieldnames from the first file
-        test_filename = "test_kem_speed_1.csv"
+        test_filename = f"{kem_speed_prefix}1.csv"
         test_filename = os.path.join(self.dir_paths['type_speed_dir'], test_filename)
 
         # Load the test file into a dataframe and put the headers into a list

--- a/scripts/parsing_scripts/parse_results.py
+++ b/scripts/parsing_scripts/parse_results.py
@@ -13,6 +13,7 @@ of the original algorithm list files used for testing.
 #------------------------------------------------------------------------------------------------------------------------------
 from internal_scripts.performance_data_parse import parse_comp_performance
 from internal_scripts.tls_performance_data_parse import parse_tls_performance
+from internal_scripts.library_config import SUPPORTED_LIBRARIES
 import os
 import sys
 import argparse
@@ -27,6 +28,8 @@ def handle_args():
     parser.add_argument('--parse-mode', type=str, help='The parsing mode to be used (computational or tls)')
     parser.add_argument('--machine-id', type=int, help='The Machine-ID of the results to be parsed')
     parser.add_argument('--total-runs', type=int, help='The number of test runs to be parsed')
+    parser.add_argument('--library', type=str, default='liboqs',
+                        help=f"PQC library that produced the results (default: liboqs). Supported: {', '.join(SUPPORTED_LIBRARIES)}. Only consulted for --parse-mode=computational.")
     parser.add_argument("--replace-old-results", action="store_true", help="Replace old results for the passed Machine-ID if this flag is set")
     
     # Parse the command line arguments
@@ -36,7 +39,8 @@ def handle_args():
         args = parser.parse_args()
         parse_mode = args.parse_mode
         machine_id = args.machine_id
-        total_runs = args.total_runs 
+        total_runs = args.total_runs
+        library = args.library
 
         # Check if the parse mode is valid (done manually to have custom error messages)
         if parse_mode == 'both':
@@ -44,6 +48,10 @@ def handle_args():
         
         elif parse_mode != "computational" and parse_mode != "tls":
             raise Exception(f"Invalid parse mode provided to the script - {parse_mode}, please use 'computational' or 'tls'")
+
+        # Validate that the library identifier is one we know how to parse
+        if library not in SUPPORTED_LIBRARIES:
+            raise Exception(f"Invalid library provided to the script - {library}, supported values are: {', '.join(SUPPORTED_LIBRARIES)}")
 
         # Determine if a machine-ID has been provided to the script
         if machine_id is not None:
@@ -154,7 +162,8 @@ def get_test_opts(root_dir):
         except ValueError:
             print("Invalid Input - Please enter a valid number!")
     
-    test_opts = [machine_num, total_runs, root_dir]
+    # Default to liboqs for interactive mode. Future versions may add a prompt for library.
+    test_opts = [machine_num, total_runs, root_dir, "liboqs"]
     return test_opts
 
 #------------------------------------------------------------------------------------------------------------------------------
@@ -182,8 +191,8 @@ def main():
 
         # Determine which parsing mode to use and get the test options
         if args.parse_mode == "computational":
-            print("Parsing Computational Performance Results")
-            comp_test_opts = [args.machine_id, args.total_runs, root_dir]
+            print(f"Parsing Computational Performance Results ({args.library})")
+            comp_test_opts = [args.machine_id, args.total_runs, root_dir, args.library]
             parse_comp_performance(comp_test_opts, replace_old_results)
         
         elif args.parse_mode == "tls":

--- a/scripts/test_scripts/pqc_performance_test.sh
+++ b/scripts/test_scripts/pqc_performance_test.sh
@@ -514,9 +514,9 @@ function setup_test_suite() {
 
     done
 
-    # Set the alg-list txt filepaths
-    kem_alg_file="$test_data_dir/alg_lists/kem_algs.txt"
-    sig_alg_file="$test_data_dir/alg_lists/sig_algs.txt"
+    # Set the alg-list txt filepaths (per-library naming so multiple backends can coexist)
+    kem_alg_file="$test_data_dir/alg_lists/kem_algs_liboqs.txt"
+    sig_alg_file="$test_data_dir/alg_lists/sig_algs_liboqs.txt"
 
     # Create the PQC KEM and digital signature algorithm list arrays
     kem_algs=()

--- a/scripts/test_scripts/pqc_performance_test.sh
+++ b/scripts/test_scripts/pqc_performance_test.sh
@@ -666,6 +666,7 @@ function handle_result_parsing() {
             # Call the result parsing script to parse the results with the replace flag not set
             python3 "$result_parser_script" \
                 --parse-mode="computational"  \
+                --library="liboqs" \
                 --machine-id="$machine_num" \
                 --total-runs=$number_of_runs
             exit_status=$?
@@ -675,6 +676,7 @@ function handle_result_parsing() {
             # Call the result parsing script to parse the results with the replace flag set
             python3 "$result_parser_script" \
                 --parse-mode="computational"  \
+                --library="liboqs" \
                 --machine-id="$machine_num" \
                 --total-runs=$number_of_runs \
                 --replace-old-results

--- a/scripts/utility_scripts/get_algorithms.py
+++ b/scripts/utility_scripts/get_algorithms.py
@@ -174,11 +174,12 @@ def get_liboqs_algs():
                 # Extract the algorithms from the stderr
                 algs = liboqs_extract_algs(stderr)
 
-                # Set the output filename for the current algorithm type
+                # Set the output filename for the current algorithm type (per-library naming
+                # so that multiple backends can coexist under test_data/alg_lists/)
                 if "kem" in bin:
-                    alg_list_file = os.path.join(output_dir, "kem_algs.txt")
+                    alg_list_file = os.path.join(output_dir, "kem_algs_liboqs.txt")
                 else:
-                    alg_list_file = os.path.join(output_dir, "sig_algs.txt")
+                    alg_list_file = os.path.join(output_dir, "sig_algs_liboqs.txt")
 
                 # Filter out HQC KEM algorithms from the list if the HQC enabled flag is not set (temp fix for HQC bug)
                 if not os.path.exists(os.path.join(root_dir, "tmp", ".hqc_enabled.flag")):

--- a/setup.sh
+++ b/setup.sh
@@ -1143,7 +1143,7 @@ function setup_controller() {
                 rm -rf $tmp_dir/liboqs_source $tmp_dir/openssl_$openssl_version $tmp_dir/oqs_provider_source # temp removal for hqc bug fix
 
                 # Check if the Liboqs alg-list files are present before deciding which alg-list files need generating
-                if [ -f "$alg_lists_dir/kem_algs.txt" ] && [ -f "$alg_lists_dir/sig_algs.txt" ]; then
+                if [ -f "$alg_lists_dir/kem_algs_liboqs.txt" ] && [ -f "$alg_lists_dir/sig_algs_liboqs.txt" ]; then
                     alg_list_flag="3"
                 else
                     alg_list_flag="2"


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #102.** This PR's standalone change is +25/-16 across 6 files
> (alg-list rename + LIBRARY_PREFIXES extension). The GitHub diff against
> `develop` shows +112/-45 across 9 files because it currently includes #102.
> Once #102 merges, this PR's diff will collapse to the standalone size.
> Suggested review order: #102 first, then this PR.

## Context

Follow-up to #102. The library-aware framework PR established `LIBRARY_PREFIXES`
and the `--library` CLI flag but kept the alg-list filenames (`kem_algs.txt`,
`sig_algs.txt`) hard-coded — only the speed-result filename prefixes were
parameterized. This PR completes the rename half of the same refactor so each
backend can ship its own alg list under `test_data/alg_lists/` without filename
collision when wolfSSL and CIRCL land.

Tracking issue: #101.

## What changes

- `test_data/alg_lists/kem_algs.txt` → `kem_algs_liboqs.txt`
- `test_data/alg_lists/sig_algs.txt` → `sig_algs_liboqs.txt`
- `LIBRARY_PREFIXES["liboqs"]` gains two entries — `kem_algs_file` and
  `sig_algs_file` — each holding the full basename including `.txt`. Future
  backends add the same pair of keys when registering.
- `setup_parse_env(root_dir)` becomes `setup_parse_env(root_dir, library)` and
  resolves the alg-list filenames from `LIBRARY_PREFIXES[library]` instead of
  hard-coding `kem_algs.txt` / `sig_algs.txt`. `parse_comp_performance` passes
  the selected library through.
- All five computational-path call sites updated:
  - `setup.sh:1146`
  - `cleaner.sh:143-144`
  - `scripts/utility_scripts/get_algorithms.py:179-181`
  - `scripts/test_scripts/pqc_performance_test.sh:518-519`
  - `scripts/parsing_scripts/internal_scripts/performance_data_parse.py:43-44`

## What does NOT change

- TLS alg-list filenames (`tls_kem_algs.txt`, `tls_hybr_sig_algs.txt`, etc.) are
  unchanged. They live in a separate namespace not consumed by `--library` and
  did not have the collision problem this PR addresses.
- Parser CLI surface is unchanged — `parse_results.py --library=liboqs` remains
  the default behaviour.
- Outputs for fresh installs are identical to current `develop`, just sourced
  from the renamed files.

## Migration

Existing installs with `test_data/alg_lists/kem_algs.txt` from a prior setup
need one of:

1. Re-run `setup.sh` (cheapest if liboqs is still built — `get_algorithms.py`
   regenerates both files under the new names within seconds).
2. Manually rename:
   ```
   cd test_data/alg_lists
   mv kem_algs.txt kem_algs_liboqs.txt
   mv sig_algs.txt sig_algs_liboqs.txt
   ```

No fallback to the legacy names is included intentionally — the simpler diff is
easier to reason about, and the migration is a one-shot rename.

## Verification

- Python (`py_compile`) and bash (`bash -n`) syntax checks pass for all six
  modified files.
- `LIBRARY_PREFIXES["liboqs"]["kem_algs_file"]` / `["sig_algs_file"]` confirmed
  present and addressable.
- The repo has no automated test suite; reviewer should spot-check that the
  fresh `setup.sh` → `pqc_performance_test.sh` → `parse_results.py` pipeline
  produces equivalent CSV outputs to current `develop`, just sourced from the
  renamed files.